### PR TITLE
Extend Convertible `FromXXXX` interfaces to return static as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "kununu/scripts": ">=4.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6"
     },
     "autoload": {
         "psr-4": {

--- a/docs/convertible.md
+++ b/docs/convertible.md
@@ -9,7 +9,7 @@ This interface defines how to create a collection item from an array:
 ```php
 interface FromArray
 {
-    public static function fromArray(array $data): self;
+    public static function fromArray(array $data): self|static;
 }
 ```
 
@@ -31,7 +31,7 @@ This interface defines how to create a collection item from an integer:
 ```php
 interface FromInt
 {
-    public static function fromInt(int $value): self;
+    public static function fromInt(int $value): self|static;
 }
 ```
 
@@ -53,7 +53,7 @@ This interface defines how to create a collection item from a string:
 ```php
 interface FromString
 {
-    public static function fromString(string $value): self;
+    public static function fromString(string $value): self|static;
 }
 ```
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,9 +3,9 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd" bootstrap="vendor/autoload.php"
          colors="true" beStrictAboutChangesToGlobalState="true">
-    <coverage processUncoveredFiles="true">
+    <coverage includeUncoveredFiles="true">
         <include>
-            <directory>./src</directory>
+            <directory>src/</directory>
         </include>
         <report>
             <clover outputFile="tests/.results/tests-clover.xml"/>
@@ -14,7 +14,7 @@
     </coverage>
     <testsuites>
         <testsuite name="Collections Test Suite">
-            <directory>./tests/</directory>
+            <directory>tests/</directory>
         </testsuite>
     </testsuites>
     <logging>

--- a/src/Convertible/FromArray.php
+++ b/src/Convertible/FromArray.php
@@ -5,5 +5,5 @@ namespace Kununu\Collection\Convertible;
 
 interface FromArray
 {
-    public static function fromArray(array $data): self;
+    public static function fromArray(array $data): self|static;
 }

--- a/src/Convertible/FromInt.php
+++ b/src/Convertible/FromInt.php
@@ -5,5 +5,5 @@ namespace Kununu\Collection\Convertible;
 
 interface FromInt
 {
-    public static function fromInt(int $value): self;
+    public static function fromInt(int $value): self|static;
 }

--- a/src/Convertible/FromString.php
+++ b/src/Convertible/FromString.php
@@ -5,5 +5,5 @@ namespace Kununu\Collection\Convertible;
 
 interface FromString
 {
-    public static function fromString(string $value): self;
+    public static function fromString(string $value): self|static;
 }


### PR DESCRIPTION
# Description

The objective of this PR is to extend the Convertible `FromXXXX` interfaces methods to return `self|static` instead of just `self`.

## Details

- Make `FromArray::fromArray` return `self|static`
- Make `FromInt::fromInt` return `self|static`
- Make `FromString::fromString` return `self|static`