### PR TITLE
Improve AbstractItem default builders

### DIFF
--- a/docs/abstract-item.md
+++ b/docs/abstract-item.md
@@ -87,10 +87,10 @@ Example:
 
 ```php
 /**
- * @method null|int getId()
- * @method null|string getName()
- * @method null|DateTime getCreatedAt()
- * @method null|string getExtraFieldNotUsedInBuild()
+ * @method int|null getId()
+ * @method string|null getName()
+ * @method DateTime|null getCreatedAt()
+ * @method string|null getExtraFieldNotUsedInBuild()
  * @method MyItem setId(?int $id)
  * @method MyItem setName(?string $name)
  * @method MyItem setCreatedAt(?DateTime $createdAt)
@@ -120,7 +120,7 @@ As said above the class can help you to build your instances from data stored in
 
 But in order for it to work your subclass must override the `getBuilders` static method.
 
-This method will basically return a map of property => callable to get data for the property:
+This method will basically return a map of `'property'` => `callable` to get data for the property:
 
 ```php
 [
@@ -133,86 +133,142 @@ This method will basically return a map of property => callable to get data for 
 ##### buildStringGetter
 
 ```php
-protected static function buildStringGetter(string $fieldName, ?string $default = null): callable;
+protected static function buildStringGetter(string $fieldName, ?string $default = null, bool $useSnakeCase = false): callable;
 ```
 
-Returns a `string` or `$default` value from the `$fieldName` in the data
+Returns a `string` or `$default` value from the `$fieldName` in the data.
+
+If `$useSnakeCase` is `true` the `$fieldName` will be converted to snake case and that value should be the key of the field in the data array. 
 
 ##### buildRequiredStringGetter
 
 ```php
-protected static function buildRequiredStringGetter(string $fieldName): callable;
+protected static function buildRequiredStringGetter(string $fieldName, bool $useSnakeCase = false): callable;
 ```
 
 Returns a `string` from the `$fieldName` in the data or throws an exception if no data is found.
 
+If `$useSnakeCase` is `true` the `$fieldName` will be converted to snake case and that value should be the key of the field in the data array.
+
 ##### buildBoolGetter
 
 ```php
-protected static function buildBoolGetter(string $fieldName, ?bool $default = null): callable;
+protected static function buildBoolGetter(string $fieldName, ?bool $default = null,bool $useSnakeCase = false): callable;
 ```
 
 Returns a `bool` or `$default` value from the `$fieldName` in the data
 
+If `$useSnakeCase` is `true` the `$fieldName` will be converted to snake case and that value should be the key of the field in the data array.
+
 ##### buildRequiredBoolGetter
 
 ```php
-protected static function buildRequiredBoolGetter(string $fieldName): callable;
+protected static function buildRequiredBoolGetter(string $fieldName, bool $useSnakeCase = false): callable;
 ```
 
 Returns a `bool` from the `$fieldName` in the data or throws an exception if no data is found.
 
+If `$useSnakeCase` is `true` the `$fieldName` will be converted to snake case and that value should be the key of the field in the data array.
+
 ##### buildIntGetter
 
 ```php
-protected static function buildIntGetter(string $fieldName, ?int $default = null): callable;
+protected static function buildIntGetter(string $fieldName, ?int $default = null, bool $useSnakeCase = false): callable;
 ```
 
 Returns an `int` or `$default` value from the `$fieldName` in the data
 
+If `$useSnakeCase` is `true` the `$fieldName` will be converted to snake case and that value should be the key of the field in the data array.
+
 ##### buildRequiredIntGetter
 
 ```php
-protected static function buildRequiredIntGetter(string $fieldName): callable;
+protected static function buildRequiredIntGetter(string $fieldName, bool $useSnakeCase = false): callable;
 ```
 
 Returns an `int` from the `$fieldName` in the data or throws an exception if no data is found.
 
+If `$useSnakeCase` is `true` the `$fieldName` will be converted to snake case and that value should be the key of the field in the data array.
+
 ##### buildFloatGetter
 
 ```php
-protected static function buildFloatGetter(string $fieldName, ?float $default = null): callable;
+protected static function buildFloatGetter(string $fieldName, ?float $default = null, bool $useSnakeCase = false): callable;
 ```
 
 Returns a `float` or `$default` value from the `$fieldName` in the data
 
+If `$useSnakeCase` is `true` the `$fieldName` will be converted to snake case and that value should be the key of the field in the data array.
+
 ##### buildRequiredFloatGetter
 
 ```php
-protected static function buildRequiredFloatGetter(string $fieldName): callable;
+protected static function buildRequiredFloatGetter(string $fieldName, bool $useSnakeCase = false): callable;
 ```
 
 Returns a `float` from the `$fieldName` in the data or throws an exception if no data is found.
 
+If `$useSnakeCase` is `true` the `$fieldName` will be converted to snake case and that value should be the key of the field in the data array.
+
 ##### buildDateTimeGetter
 
 ```php
-protected static function buildDateTimeGetter(string $fieldName, string $dateFormat = self::DATE_FORMAT, ?DateTimeInterface $default = null): callable
+protected static function buildDateTimeGetter(string $fieldName, string $dateFormat = AbstractItem::DATE_FORMAT, ?DateTimeInterface $default = null, bool $useSnakeCase = false): callable;
 ```
 
-Returns a `DateTimeInterface` or `$default` value from the `$fieldName` in the data.
+Returns a `DateTime` or `$default` value from the `$fieldName` in the data.
 
 The `$dateFormat` by default is `'Y-m-d H:i:s'`.
+
+If `$useSnakeCase` is `true` the `$fieldName` will be converted to snake case and that value should be the key of the field in the data array.
 
 ##### buildRequiredDateTimeGetter
 
 ```php
-protected static function buildRequiredDateTimeGetter(string $fieldName, string $dateFormat = self::DATE_FORMAT): callable;
+protected static function buildRequiredDateTimeGetter(string $fieldName, string $dateFormat = AbstractItem::DATE_FORMAT, bool $useSnakeCase = false): callable;
 ```
 
-Returns a `DateTimeInterface` from the `$fieldName` in the data or throws an exception if no data is found.
+Returns a `DateTime` from the `$fieldName` in the data or throws an exception if no data is found.
 
 The `$dateFormat` by default is `'Y-m-d H:i:s'`.
+
+If `$useSnakeCase` is `true` the `$fieldName` will be converted to snake case and that value should be the key of the field in the data array.
+
+##### buildDateTimeImmutableGetter
+
+```php
+protected static function buildDateTimeImmutableGetter(string $fieldName, string $dateFormat = AbstractItem::DATE_FORMAT, ?DateTimeInterface $default = null, bool $useSnakeCase = false): callable;
+```
+
+Returns a `DateTimeImmutable` or `$default` value from the `$fieldName` in the data.
+
+The `$dateFormat` by default is `'Y-m-d H:i:s'`.
+
+If `$useSnakeCase` is `true` the `$fieldName` will be converted to snake case and that value should be the key of the field in the data array.
+
+##### buildRequiredDateTimeImmutableGetter
+
+```php
+protected static function buildRequiredDateTimeImmutableGetter(string $fieldName, string $dateFormat = AbstractItem::DATE_FORMAT, bool $useSnakeCase = false): callable;
+```
+
+Returns a `DateTimeImmutable` from the `$fieldName` in the data or throws an exception if no data is found.
+
+The `$dateFormat` by default is `'Y-m-d H:i:s'`.
+
+If `$useSnakeCase` is `true` the `$fieldName` will be converted to snake case and that value should be the key of the field in the data array.
+
+##### buildGetterOptionalField
+
+```php
+protected static function buildGetterOptionalField(string $fieldName, callable $converter, mixed $default = null, bool $useSnakeCase = false): callable;
+```
+
+Returns a value or `$default` value from the `$fieldName` in the data.
+
+The `$converter` callable should implement the logic assuming that the `$fieldName` exists in the data, and it will receive the `$value` on that field.
+
+If `$useSnakeCase` is `true` the `$fieldName` will be converted to snake case and that value should be the key of the field in the data array.
 
 ##### buildGetterRequiredField
 
@@ -222,12 +278,29 @@ protected static function buildGetterRequiredField(string $fieldName, callable $
 
 Returns a value from the `$fieldName` in the data or throws an exception if no data is found.
 
-The `$converter` callable should implement the logic assuming that the `$fieldName` exists in the data and it will receive the `$value` on that field.
+The `$converter` callable should implement the logic assuming that the `$fieldName` exists in the data, and it will receive the `$value` on that field.
+
+If `$useSnakeCase` is `true` the `$fieldName` will be converted to snake case and that value should be the key of the field in the data array.
+
+##### buildFromArrayGetter
+
+```php
+protected static function buildFromArrayGetter(string $fieldName, string $fromArrayClass, ?FromArray $default = null, bool $useSnakeCase = false): callable; 
+```
+
+Try to create an `FromArray` concrete implementation instance which class is `$fromArrayClass` from the `$fieldName` in the data.
+
+The `$fieldName` in the data must be an `array` suited to be passed to the static `fromArray` method of your `$collectionClass`.
+
+- If `$fromArrayClass` is not a concrete subclass of `FromArray` it will return `null`.
+- If `$fieldName` is not set in the data array it will return the `$default` instance (which by default is `null`).
+
+If `$useSnakeCase` is `true` the `$fieldName` will be converted to snake case and that value should be the key of the field in the data array.
 
 ##### buildCollectionGetter
 
 ```php
-protected static function buildCollectionGetter(string $fieldName, string $collectionClass, ?AbstractCollection $default = null): callable;
+protected static function buildCollectionGetter(string $fieldName, string $collectionClass, ?AbstractCollection $default = null, bool $useSnakeCase = false): callable;
 ```
 
 Try to create an `AbstractCollection` concrete implementation instance which class is `$collectionClass` from the `$fieldName` in the data.
@@ -237,15 +310,19 @@ The `$fieldName` in the data must be an `iterable` suited to be passed to the st
 - If `$collectionClass` is not a concrete subclass of `AbstractCollection` it will return `null`.
 - If `$fieldName` is not set in the data array it will return the `$default` instance (which by default is `null`).
 
+If `$useSnakeCase` is `true` the `$fieldName` will be converted to snake case and that value should be the key of the field in the data array.
+
 ##### buildConditionalGetter
 
 ```php
-protected static function buildConditionalGetter(string $sourceField, array $sources): callable;
+protected static function buildConditionalGetter(string $sourceField, array $sources, bool $useSnakeCase = false): callable;
 ```
 
 Builds a field based on the `$sourceField` value (the condition). The `$sourceField` should have the key used to select the `callable` mapped on the `$sources` array.
 
 The `$sources` array has the format `['sourceName1' => callableForSource1(), ..., 'sourceNameN' => callableForSourceN()]` 
+
+If `$useSnakeCase` is `true` the `$sourceField` will be converted to snake case and that value should be the key of the field in the data array.
 
 Example:
 ```php

--- a/tests/AbstractItemTest.php
+++ b/tests/AbstractItemTest.php
@@ -5,13 +5,17 @@ namespace Kununu\Collection\Tests;
 
 use BadMethodCallException;
 use DateTime;
+use DateTimeImmutable;
 use InvalidArgumentException;
+use Kununu\Collection\Tests\Stub\AbstractItemSnakeCaseStub;
 use Kununu\Collection\Tests\Stub\AbstractItemStub;
 use Kununu\Collection\Tests\Stub\AbstractItemWithCollectionsStub;
 use Kununu\Collection\Tests\Stub\AbstractItemWithConditionalBuilderStub;
+use Kununu\Collection\Tests\Stub\AbstractItemWithFromArrayStub;
 use Kununu\Collection\Tests\Stub\AbstractItemWithRequiredFieldsStub;
 use Kununu\Collection\Tests\Stub\DTOCollectionStub;
 use Kununu\Collection\Tests\Stub\DTOStub;
+use Kununu\Collection\Tests\Stub\FromArrayStub;
 use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
 
@@ -241,6 +245,21 @@ final class AbstractItemTest extends TestCase
         ];
     }
 
+    public function testItemBuildFromArray(): void
+    {
+        $item = AbstractItemWithFromArrayStub::build([
+            'fromArray' => ['id' => 1, 'name' => 'The Name'],
+        ]);
+
+        $this->assertInstanceOf(FromArrayStub::class, $item->fromArray());
+        $this->assertEquals(1, $item->fromArray()->id());
+        $this->assertEquals('The Name', $item->fromArray()->name());
+        $this->assertNull($item->notFromArray());
+        $this->assertInstanceOf(FromArrayStub::class, $item->defaultFromArray());
+        $this->assertEquals(0, $item->defaultFromArray()->id());
+        $this->assertEquals('', $item->defaultFromArray()->name());
+    }
+
     public function testItemBuildCollection(): void
     {
         $item = AbstractItemWithCollectionsStub::build([
@@ -338,5 +357,48 @@ final class AbstractItemTest extends TestCase
             'Kununu\Collection\Tests\Stub\AbstractItemStub: Invalid method "withInvalidProperty" called'
         );
         $item->withInvalidProperty(false);
+    }
+
+    public function testItemBuilderWithSnakeCase(): void
+    {
+        $item = AbstractItemSnakeCaseStub::build([
+            'string_field'                       => 'The string field',
+            'required_string_field'              => 'The required string field',
+            'bool_field'                         => true,
+            'required_bool_field'                => false,
+            'int_field'                          => 1,
+            'required_int_field'                 => 2,
+            'float_field'                        => 1.5,
+            'required_float_field'               => 2.6,
+            'date_time_field'                    => '2023-10-11 12:34:01',
+            'required_date_time_field'           => '2023-10-11 12:34:02',
+            'date_time_immutable_field'          => '2023-10-11 12:34:03',
+            'required_date_time_immutable_field' => '2023-10-11 12:34:04',
+        ]);
+
+        $this->assertEquals('The string field', $item->stringField());
+        $this->assertEquals('The required string field', $item->requiredStringField());
+        $this->assertTrue($item->boolField());
+        $this->assertFalse($item->requiredBoolField());
+        $this->assertEquals(1, $item->intField());
+        $this->assertEquals(2, $item->requiredIntField());
+        $this->assertEquals(1.5, $item->floatField());
+        $this->assertEquals(2.6, $item->requiredFloatField());
+        $this->assertEquals(
+            DateTime::createFromFormat('Y-m-d H:i:s', '2023-10-11 12:34:01'),
+            $item->dateTimeField()
+        );
+        $this->assertEquals(
+            DateTime::createFromFormat('Y-m-d H:i:s', '2023-10-11 12:34:02'),
+            $item->requiredDateTimeField()
+        );
+        $this->assertEquals(
+            DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2023-10-11 12:34:03'),
+            $item->dateTimeImmutableField()
+        );
+        $this->assertEquals(
+            DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2023-10-11 12:34:04'),
+            $item->requiredDateTimeImmutableField()
+        );
     }
 }

--- a/tests/Stub/AbstractItemSnakeCaseStub.php
+++ b/tests/Stub/AbstractItemSnakeCaseStub.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Collection\Tests\Stub;
+
+use DateTime;
+use DateTimeImmutable;
+use Kununu\Collection\AbstractItem;
+
+/**
+ * @method string|null            stringField()
+ * @method string                 requiredStringField()
+ * @method bool|null              boolField()
+ * @method bool                   requiredBoolField()
+ * @method int|null               intField()
+ * @method int                    requiredIntField()
+ * @method float|null             floatField()
+ * @method float                  requiredFloatField()
+ * @method DateTime|null          dateTimeField()
+ * @method DateTime               requiredDateTimeField()
+ * @method DateTimeImmutable|null dateTimeImmutableField()
+ * @method DateTimeImmutable      requiredDateTimeImmutableField()
+ */
+final class AbstractItemSnakeCaseStub extends AbstractItem
+{
+    protected const GETTER_PREFIX = '';
+
+    protected const PROPERTIES = [
+        'stringField',
+        'requiredStringField',
+        'boolField',
+        'requiredBoolField',
+        'intField',
+        'requiredIntField',
+        'floatField',
+        'requiredFloatField',
+        'dateTimeField',
+        'requiredDateTimeField',
+        'dateTimeImmutableField',
+        'requiredDateTimeImmutableField',
+    ];
+
+    protected static function getBuilders(): array
+    {
+        return [
+            'stringField'                    => self::buildStringGetter('stringField', useSnakeCase: true),
+            'requiredStringField'            => self::buildRequiredStringGetter('requiredStringField', true),
+            'boolField'                      => self::buildBoolGetter('boolField', useSnakeCase: true),
+            'requiredBoolField'              => self::buildRequiredBoolGetter('requiredBoolField', true),
+            'intField'                       => self::buildIntGetter('intField', useSnakeCase: true),
+            'requiredIntField'               => self::buildRequiredIntGetter('requiredIntField', true),
+            'floatField'                     => self::buildFloatGetter('floatField', useSnakeCase: true),
+            'requiredFloatField'             => self::buildRequiredFloatGetter('requiredFloatField', true),
+            'dateTimeField'                  => self::buildDateTimeGetter('dateTimeField', useSnakeCase: true),
+            'requiredDateTimeField'          => self::buildRequiredDateTimeGetter(
+                'requiredDateTimeField',
+                useSnakeCase: true
+            ),
+            'dateTimeImmutableField'         => self::buildDateTimeImmutableGetter(
+                'dateTimeImmutableField',
+                useSnakeCase: true
+            ),
+            'requiredDateTimeImmutableField' => self::buildRequiredDateTimeImmutableGetter(
+                'requiredDateTimeImmutableField',
+                useSnakeCase: true
+            ),
+        ];
+    }
+}

--- a/tests/Stub/AbstractItemWithFromArrayStub.php
+++ b/tests/Stub/AbstractItemWithFromArrayStub.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Collection\Tests\Stub;
+
+use Kununu\Collection\AbstractItem;
+
+/**
+ * @method FromArrayStub|null fromArray()
+ * @method FromArrayStub|null notFromArray()
+ * @method FromArrayStub|null defaultFromArray()
+ */
+final class AbstractItemWithFromArrayStub extends AbstractItem
+{
+    protected const GETTER_PREFIX = '';
+
+    protected const PROPERTIES = [
+        'fromArray',
+        'notFromArray',
+        'defaultFromArray',
+    ];
+
+    protected static function getBuilders(): array
+    {
+        return [
+            'fromArray'        => self::buildFromArrayGetter('fromArray', FromArrayStub::class),
+            'notFromArray'     => self::buildFromArrayGetter('notFromArray', 'ThisIsNotACollectionClass'),
+            'defaultFromArray' => self::buildFromArrayGetter(
+                'defaultFromArray',
+                FromArrayStub::class,
+                new FromArrayStub(0, '')
+            ),
+        ];
+    }
+}

--- a/tests/Stub/FromArrayStub.php
+++ b/tests/Stub/FromArrayStub.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Collection\Tests\Stub;
+
+use Kununu\Collection\Convertible\FromArray;
+
+final class FromArrayStub implements FromArray
+{
+    public function __construct(private int $id, private string $name)
+    {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self((int) $data['id'], (string) $data['name']);
+    }
+
+    public function id(): int
+    {
+        return $this->id;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+}


### PR DESCRIPTION
# Description

The objective of this PR is to improve AbstractItem` default builders.

## Details
- Add `buildGetterOptionalField`
- Add `buildFromArrayGetter`
- Add `$useSnakeCase` parameter to all default builders to allow to convert name of properties to snake_case when getting data in the source array
