### PR TITLE
Update continuous integration components

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,6 @@ updates:
     # Disable automatic rebasing to prevent overloading our CICD system
     rebase-strategy: "disabled"
     versioning-strategy: auto
-    # By default Dependabot has a limit of the number of open PR for version updates
+    # By default, Dependabot has a limit of the number of open PR for version updates
     # and security updates.
     # See other defaults in here: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -33,7 +33,7 @@ jobs:
           coverage: xdebug
 
       - name: Install Composer Dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
         with:
           dependency-versions: ${{ matrix.dependencies }}
           composer-options: "--prefer-stable"
@@ -42,7 +42,7 @@ jobs:
         run: vendor/bin/phpunit
 
       - name: Upload coverage files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.job }}-${{ matrix.php-version }}-coverage
           path: tests/.results/
@@ -51,12 +51,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: build-8-coverage
           path: tests/.results/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,15 @@
 
 Contributions are more than **welcome**.
 
-We accept contributions via Pull Requests on [Github](https://github.com/kununu/collections).
+We accept contributions via Pull Requests on [GitHub](https://github.com/kununu/collections).
 
 ## Pull Requests
 
 - **[kununu Coding Standards](https://github.com/kununu/kununu-scripts)** - The kununu coding standards are an extension of the [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md). Check out [kununu Coding Standards](https://github.com/kununu/kununu-scripts) for more details. In development mode the package [kununu-scripts](https://github.com/kununu/kununu-scripts) is already a dependency that expose commands that you can use to meet our standards.
-  
-- **Add tests!** - to ensure a high quality code base, your code patch can't be accepted if it doesn't have tests.
 
-- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
+- **Add tests!** - to ensure a high quality code base, your code patch can't be accepted if it does not have tests.
+
+- **Document any change in behaviour** - Make sure the `CHANGELOG.md`, `README.md` and any other relevant documentation are kept up-to-date.
 
 - **Consider our release cycle** - Since we're using semantic versioning ([SemVer v2.0.0](http://semver.org/)). Changes to the API must be done with great consideration, and prevented if at all possible.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-present kununu GmbH
+Copyright (c) 2020-present kununu GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ composer install
 composer test
 ```
 
+To run test and generate coverage information:
+
+```bash
+composer install
+composer test-coverage
+```
+
 ## Usage
 
 The library provide three traits that you can add to your custom class extending `ArrayIterator`.
@@ -47,7 +54,6 @@ More details:
 ## Contribute
 
 If you are interested in contributing read our [contributing guidelines](/CONTRIBUTING.md).
-
 
 ------------------------------
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,16 +9,16 @@ Additionally, if you have a fix then please create a pull request and link it to
 
 ### Reporting a Vulnerability
 
-Jira is our entrypoint to report security vulnerabilities. Having this mind a KUNSECU user story (type Vulnerability) needs to be created. 
+Jira is our entrypoint to report security vulnerabilities. Having this in mind a KUNSECU user story (type Vulnerability) needs to be created.
 
-#### How to fill the user story? 
+#### How to fill the user story?
 
-Follow this [documentation](https://confluence.xing.hh/pages/viewpage.action?pageId=381133070).
+Follow this [documentation](https://new-work.atlassian.net/wiki/spaces/kununu/pages/47846323/Vulnerability+Issue+Type+Jira).
 
-#### To which team do I assign the user story? 
+#### To which team do I assign the user story?
 
-Follow the [component ownership matrix](https://confluence.xing.hh/display/kununu/Component+ownership+and+support) and assign it to the corresponding team.
+Follow the [domain ownership matrix](https://new-work.atlassian.net/wiki/spaces/kununu/pages/113148000/Domain+ownership+matrix) and assign it to the corresponding team.
 
 ## Reporting the update of dependencies
 
-This is the benefit of having Dependabot. It will open pull requests for security and version updates. For more information check the Github [documentation](https://docs.github.com/en/github/administering-a-repository/managing-pull-requests-for-dependency-updates).
+This is the benefit of having Dependabot. It will open pull requests for security and version updates. For more information check the GitHub [documentation](https://docs.github.com/en/github/administering-a-repository/managing-pull-requests-for-dependency-updates).

--- a/composer.json
+++ b/composer.json
@@ -1,46 +1,47 @@
 {
-    "name": "kununu/collections",
-    "description": "To reduce boilerplate associated with collections",
-    "license": "MIT",
-    "minimum-stability": "stable",
-    "keywords": [
-        "collections"
-    ],
-    "authors": [
-        {
-            "name": "Hugo Gonçalves",
-            "email": "hugo.goncalves@kununu.com"
-        }
-    ],
-    "require": {
-        "php": ">=8.0"
-    },
-    "require-dev": {
-        "kununu/scripts": ">=4.0",
-        "phpunit/phpunit": "^9.6"
-    },
-    "autoload": {
-        "psr-4": {
-            "Kununu\\Collection\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Kununu\\Collection\\Tests\\": "tests/"
-        }
-    },
-    "scripts": {
-        "test": "phpunit --no-coverage tests",
-        "test-coverage": "phpunit --coverage-clover tests/.results/coverage.xml --coverage-html tests/.results/html/ tests"
-    },
-    "scripts-descriptions": {
-        "test": "Run all tests",
-        "test-coverage": "Run all tests with coverage report"
-    },
-    "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "kununu/scripts": true
-        }
+  "name": "kununu/collections",
+  "description": "To reduce boilerplate associated with collections",
+  "type": "library",
+  "license": "MIT",
+  "minimum-stability": "stable",
+  "keywords": [
+    "collections"
+  ],
+  "authors": [
+    {
+      "name": "Hugo Gonçalves",
+      "email": "hugo.goncalves@kununu.com"
     }
+  ],
+  "require": {
+    "php": ">=8.0"
+  },
+  "require-dev": {
+    "kununu/scripts": ">=4.0",
+    "phpunit/phpunit": "^9.6"
+  },
+  "autoload": {
+    "psr-4": {
+      "Kununu\\Collection\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Kununu\\Collection\\Tests\\": "tests/"
+    }
+  },
+  "scripts": {
+    "test": "phpunit --no-coverage tests",
+    "test-coverage": "XDEBUG_MODE=coverage phpunit --coverage-clover tests/.results/coverage.xml --coverage-html tests/.results/html/ tests"
+  },
+  "scripts-descriptions": {
+    "test": "Run all tests",
+    "test-coverage": "Run all tests with coverage report"
+  },
+  "config": {
+    "sort-packages": true,
+    "allow-plugins": {
+      "kununu/scripts": true
+    }
+  }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,22 +2,22 @@
 <!-- https://phpunit.readthedocs.io/en/9.6/ -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd" bootstrap="vendor/autoload.php"
-         colors="true" beStrictAboutChangesToGlobalState="true">
-    <coverage includeUncoveredFiles="true">
-        <include>
-            <directory>src/</directory>
-        </include>
-        <report>
-            <clover outputFile="tests/.results/tests-clover.xml"/>
-            <html outputDirectory="tests/.results/html/"/>
-        </report>
-    </coverage>
-    <testsuites>
-        <testsuite name="Collections Test Suite">
-            <directory>tests/</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <junit outputFile="tests/.results/tests-junit.xml"/>
-    </logging>
+         colors="true" beStrictAboutChangesToGlobalState="true" testdox="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory>src</directory>
+    </include>
+    <report>
+      <clover outputFile="tests/.results/tests-clover.xml"/>
+      <html outputDirectory="tests/.results/html/"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Collections Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="tests/.results/tests-junit.xml"/>
+  </logging>
 </phpunit>


### PR DESCRIPTION
# Description

The objective of this PR is to update the components used in continuous integration GitHub actions

## Details
- Update continuous integration components:
  - `actions/checkout` to v4
  - `ramsey/composer-install` to v2
  - `actions/upload-artifact` to v4
  - `actions/download-artifact` to v4
- Update links and typos in documentation
