### PR TITLE
Introduce collections interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,17 @@ composer test-coverage
 
 ## Usage
 
-The library provide three traits that you can add to your custom class extending `ArrayIterator`.
+The library defines interfaces to deal with collections and also boilerplate code with default implementations.
+
+You can either use the provided traits to your custom class extending `ArrayIterator` or simply expand the abstract collection classes using them.
+
+It has a default implementation for a "basic" collection and also one to filter and group data on your collections (a "filterable" collection).
 
 It defines interfaces to convert collection items to `array`, `string` and `int` and to compare items.
 
-It also provides some interfaces to filter and group data on your collections and base classes with default implementations.
-
 More details:
 
+- [Collection Interfaces](docs/collection-interfaces.md)
 - [Collection Trait](docs/collection-trait.md)
 - [Filterable Collection Trait](docs/filterable-collection-trait.md)
 - [Auto Sortable OffsetSet Trait](docs/autosortable-offsetset-trait.md)

--- a/docs/abstract-collections.md
+++ b/docs/abstract-collections.md
@@ -2,7 +2,7 @@
 
 ## AbstractCollection
 
-This is an abstract base class that you can use for your collections. It extends `ArrayIterator` (and already uses the `CollectionTrait`) so you just need to extend it to have a proper collection class.
+This is an abstract base class that you can use for your collections. It extends `ArrayIterator` and implements the `Collection` interface (and already uses the `CollectionTrait`) so you just need to extend it to have a proper collection class.
 
 ```php
 <?php
@@ -19,7 +19,7 @@ $collection = MyCollection::fromIterable($myData);
 
 ## AbstractFilterableCollection
 
-Using the same concept as `AbstractCollection` this class extends `ArrayIterator` and add the `FilterableCollectionTrait` to it.
+Using the same concept as `AbstractCollection` this class extends `ArrayIterator` and implements the `FilterableCollection` (and already uses the `FilterableCollectionTrait`).
 
 ```php
 <?php

--- a/docs/collection-interfaces.md
+++ b/docs/collection-interfaces.md
@@ -1,0 +1,194 @@
+# Collection Interfaces
+
+The library defines two interfaces for collections.
+
+The first one ([`Collection`](../src/Collection.php)) is a basic "bare-bones" collection.
+
+The second one ([`FilterableCollection`](../src/FilterableCollection.php)) is a "filterable" collection, which allows you to filter and group elements on your collection.
+
+`FilterableCollection` extends `Collection`, so all methods should also be implemented in a `FilterableCollection` (plus the specific methods).  
+
+Every collection interface is also extending from `FromIterable` and `ToArray` interfaces. 
+
+So they should also implement the following methods:
+
+## fromIterable
+
+```php
+public static function fromIterable(iterable $data): self|static;
+```
+
+This method should try to create an instance of your collection class with data from a source that is an `iterable` (e.g. an array).
+
+## toArray
+
+```php
+public function toArray(): array;
+```
+
+This method will convert your collection to a representation of it as an array.
+
+## Collection
+
+The `Collection` interface defines the methods your collection should provide.
+
+### add
+
+```php
+public function add(mixed $value): self|static;
+```
+
+This method is defined to be a fluent version of `ArrayIterator::append`. To do stuff like:
+
+```php
+$collection->add($item1)->add($item2);
+```
+
+### diff
+
+```php
+public function diff(self $other): self|static;
+```
+
+This method will produce a collection with the difference between your collection and another instance.
+
+### duplicates
+
+```php
+public function duplicates(bool $strict = true, bool $uniques = false): self|static;
+```
+
+This method produces a collection which contains items which occur multiple times in the collection.
+
+- `$strict` parameter allows you to use strict comparison (e.g. if your implementation uses PHP `in_array`).
+- `$uniques` parameter allows you to specify if you want to return unique duplicates values instead of all duplicates entries.
+
+### each
+
+```php
+public function each(callable $function, bool $rewind = true): self|static;
+```
+
+This method will iterate through each item of a collection, optionally rewind it at the end of the iteration, calling an anonymous function where you can do whatever you need with each item.
+
+Callable signature:
+
+```php
+function(mixed $element, string|float|int|bool|null $elementKey): void;
+```
+
+### empty
+
+```php
+public function empty(): bool;
+```
+
+Just a shortcut to see if your collection has a count of elements greater than zero.
+
+### has
+
+```php
+public function has(mixed $value, bool $strict = true): bool;
+```
+
+This method will tell you if your collection contains the given value.
+ 
+- `$strict` parameter allows you to use strict comparison (e.g. if your implementation uses PHP `in_array`).
+
+### keys
+
+```php
+public function keys(): array;
+```
+
+This method will return the keys of the collection.
+
+### map
+
+```php
+public function map(callable $function, bool $rewind = true): array;
+```
+
+This method will map your collection to an array, optionally rewind it at the end of the iteration, calling an anonymous function where you can do whatever you need with each item.
+
+Callable signature:
+
+```php
+function(mixed $element, string|float|int|bool|null $elementKey): mixed;
+```
+
+### reduce
+
+```php
+public function reduce(callable $function, mixed $initial = null, bool $rewind = true): mixed;
+```
+
+This method will reduce your collection to a single value, optionally rewind it at the end of the iteration, calling an anonymous function where you can do whatever you need with each item.
+
+Callable signature:
+
+```php
+function(mixed $carry, mixed $element, string|float|int|bool|null $elementKey): mixed;
+```
+
+### reverse
+
+```php
+public function reverse(): self|static;
+```
+
+This method will produce a collection with elements of your collection in the reverse order.
+
+### unique
+
+```php
+public function unique(): self|static;
+```
+
+This method will produce a collection with distinct elements of your collection.
+
+### values
+
+```php
+public function values(): array;
+```
+
+This method will return the values of the collection.
+
+## FilterableCollection
+
+The `FilterableCollection` interface defines additional methods that your collection should provide in order to filter and/or group elements in it.
+
+### filter
+
+```php
+public function filter(CollectionFilter $filter): self|static
+```
+
+This will accept a `CollectionFilter` instance (with the definitions of the filter being applied to the collection), and returns a new collection with only the elements that have met the criteria defined in `$filter`.
+
+### groupBy
+
+```php
+public function groupBy(bool $removeEmptyGroups, CollectionFilter ...$filters): array
+```
+
+This method allows you to apply a series of filters to a collection and group the result by each filter. The `$removeEmptyGroups` flag means if we will remove or keep groups in the result without items.
+
+The result should be returned as an array with the following structure:
+
+```php
+[
+    'filter_1_key' => [
+        'item_key_1' => item object 1
+        ...
+        'item_key_N' => item object X
+     ],
+     'filter_2_key' => [
+     'item_key_1' => item object 1
+     ...
+     'item_key_N' => item object Y
+     ],
+     ...
+]
+```

--- a/docs/collection-trait.md
+++ b/docs/collection-trait.md
@@ -48,6 +48,14 @@ public function unique(): self|static;
 
 This method will produce a collection with distinct elements of your collection.
 
+## duplicates
+
+```php
+public function duplicates(): self|static;
+```
+
+This methods produces a collection which contains items which occur multiple times in the collection. Please note that this method encapsulates the php [in_array()](https://www.php.net/manual/en/function.in-array.php) method and as such can produce unexpected results when using loose checking.
+
 ## reverse
 
 ```php

--- a/docs/collection-trait.md
+++ b/docs/collection-trait.md
@@ -32,6 +32,14 @@ A fluent version of `append`. To do stuff like:
 $collection->add($item1)->add($item2);
 ```
 
+## has
+
+```php
+public function has($value, $strict): bool;
+```
+
+This method will tell you if your collection contains the given value. Please note that this method encapsulates the php [in_array()](https://www.php.net/manual/en/function.in-array.php) method and as such can produce unexpected results when using loose checking.
+
 ## unique
 
 ```php

--- a/docs/collection-trait.md
+++ b/docs/collection-trait.md
@@ -1,118 +1,14 @@
 # CollectionTrait
 
-This is the most basic trait, and it provides the following methods to your class:
+This is the most basic trait, and it provides an implementation of the `Collection` interface.
+
+Some details about the implementation:
 
 ## fromIterable
-```php
-public static function fromIterable(iterable $data): self|static;
-```
-
-This method tries to create an instance of your collection class with data from a source that is an `iterable` (e.g. an array).
 
 Internally it is iterating the items in the data source and calling the `append` method of your class (or the `ArrayIterator` one if you don't rewrite it in your class).
 
 With a concrete implementation on your class of the `append` method you can define on how to transform each iterable element into an instance of a valid object your collection will accept and handle.
-
-## empty
-```php
-public function empty(): bool;
-```
-
-Just a shortcut to see if your collection has a count of elements greater than zero.
-
-## add
-
-```php
-public function add($value): self|static;
-```
-
-A fluent version of `append`. To do stuff like:
-
-```php
-$collection->add($item1)->add($item2);
-```
-
-## has
-
-```php
-public function has($value, $strict): bool;
-```
-
-This method will tell you if your collection contains the given value. Please note that this method encapsulates the php [in_array()](https://www.php.net/manual/en/function.in-array.php) method and as such can produce unexpected results when using loose checking.
-
-## unique
-
-```php
-public function unique(): self|static;
-```
-
-This method will produce a collection with distinct elements of your collection.
-
-## duplicates
-
-```php
-public function duplicates(): self|static;
-```
-
-This methods produces a collection which contains items which occur multiple times in the collection. Please note that this method encapsulates the php [in_array()](https://www.php.net/manual/en/function.in-array.php) method and as such can produce unexpected results when using loose checking.
-
-## reverse
-
-```php
-public function reverse(): self|static;
-```
-
-This method will produce a collection with elements of your collection in the reverse order.
-
-## diff
-
-```php
-public function diff(self $other): self|static;
-```
-
-This method will produce a collection with the difference between your collection and another instance.
-
-## each
-
-```php
-public function each(callable $function, bool $rewind = true): self|static;
-```
-
-This method will iterate through each item of a collection, optionally rewind it at the end of the iteration, calling an anonymous function where you can do whatever you need with each item.
-
-Callable signature:
-
-```php
-function(mixed $element, string|float|int|bool|null $elementKey): void;
-```
-
-## map
-
-```php
-public function map(callable $function, bool $rewind = true): array;
-```
-
-This method will map your collection to an array, optionally rewind it at the end of the iteration, calling an anonymous function where you can do whatever you need with each item.
-
-Callable signature:
-
-```php
-function(mixed $element, string|float|int|bool|null $elementKey): mixed;
-```
-
-## reduce
-
-```php
-public function reduce(callable $function, mixed $initial = null, bool $rewind = true): mixed;
-```
-
-This method will reduce your collection to a single value, optionally rewind it at the end of the iteration, calling an anonymous function where you can do whatever you need with each item.
-
-Callable signature:
-
-```php
-function(mixed $carry, mixed $element, string|float|int|bool|null $elementKey): mixed;
-```
 
 ## toArray
 
@@ -122,9 +18,12 @@ public function toArray(): array;
 
 This method will convert your collection to a representation of it as an array.
 
-To take full use of this method also take a look at the `Kununu\Collection\Convertible` interfaces.
+To take full use of this method also take a look at the [Convertible](../src/Convertible) interfaces.
 
 If the members of your collection properly implement the `ToArray`, `ToInt` and `ToString` interfaces, this method will then recursively convert each field to a basic PHP representation.
+
+Also, if any element is an implementation of [Stringable](https://www.php.net/manual/en/class.stringable.php), it will convert the element to string by casting it to string (in practice it will call the `__toString` method that `Stringable` enforces).
+
 This applies also to collections that are defined inside a class that is an item in a top level collection.
 
 Example:
@@ -133,27 +32,127 @@ Example:
 <?php
 declare(strict_types=1);
 
-final class MyTopCollection implements ToArray
+use Kununu\Collection\AbstractCollection;
+
+final class MyTopCollection extends AbstractCollection
 {
-    use CollectionTrait;    
 }
 
-final class MySubCollection implements ToArray
+final class MySubCollection extends AbstractCollection
 {
-    use CollectionTrait;
+}
+
+final class MySubItem implements Stringable
+{
+    public function __construct(public readonly int $age)
+    {    
+    }
+    
+    public function __toString(): string
+    {
+        return (string) $this->age;     
+    }
 }
 
 final class MyTopItem implements ToArray
 {
-    public string $name;
-    public MySubCollection $subCollection;
+    public function __construct(public string $name, public MySubCollection $subCollection)
+    {    
+    }
 
     public function toArray(): array
     {
         return [
             'name' => $this->name,
-            'subCollection' => $this->subCollection->toArray()
+            'subCollection' => $this->subCollection->toArray(),
         ];           
     }
 }
+
+$collection = new MyTopCollection();
+
+$collection->add(
+    new MyTopItem(
+        'The Name',
+        (new MySubCollection())->add(new MySubItem(100))
+    )
+);
+
+$collection->toArray();
+
+// Will result in:
+[
+    [
+        'name' => 'The Name',
+        'subCollection' => [
+            '100'
+        ]
+    ]   
+];
 ``` 
+
+## add
+
+Internally it is call the `ArrayIterator::append` and returning the instance to allow fluent calls.
+
+## diff
+
+To check the difference between two collections first it checks that the other collection is of the same type as the current one.
+
+Then it is calling the PHP [array_diff](https://www.php.net/manual/en/function.array-diff.php) between the [serialize](https://www.php.net/manual/en/https://www.php.net/manual/en/function.serialize.php) representation of each collection represented as an array (by calling the `toArray` method on each collection).
+
+Finally, it is creating a new instance of the collection by using [unserialize](https://www.php.net/manual/en/function.unserialize) on each member of the diff.
+
+## duplicates
+
+Internally it creates two new collections. One for the non-duplicated elements. Another one for the duplicates.
+
+Internally it is iterating the collection with the `each` method and for each element checks if it is already in the non-duplicated elements collection (by using the `has` method).
+    - If it's already there the element will be added to the duplicated collection
+    - Otherwise it will be added to the non-duplicated collection
+
+Finally, it will return the duplicated collection, optionally calling the `unique` method if we don't want the same duplicated elements in the result.
+
+## each
+
+Internally, this method will iterate through each item of a collection, optionally rewind it at the end of the iteration, calling the anonymous function for each element.
+
+## empty
+
+Internally is checking if the `ArrayIterator::count` returns 0
+
+## has
+
+Internally, this method is calling the PHP [in_array](https://www.php.net/manual/en/function.in-array.php) to check if the element is in the array representation of the collection (obtained via `toArray` method).
+
+Please note that since it's using `in_array` it can produce unexpected results when using loose checking.
+
+## keys
+
+Internally, this method is calling the PHP [array_keys](https://www.php.net/manual/en/function.array-keys) of the array held in the `ArrayIterator` (via the `ArrayIterator::getArrayCopy` method)
+
+## map
+
+Internally, this method will iterate through your collection, optionally rewind it at the end of the iteration, calling the anonymous function and storing the result of that call in an array which is the result.
+
+## reduce
+
+Internally, this method will reduce your collection to a single value, optionally rewind it at the end of the iteration, calling the anonymous function for each element and updating the `$initial` value with the result of the call.
+
+Finally, it will return the updated `$initial` value as the result of the reduction.
+
+## reverse
+
+Internally, this method will call the PHP [array_reverse](https://www.php.net/manual/en/function.array-reverse) on the array representation of the collection (obtained via `toArray` method).
+
+Then it will create and return a new instance of the collection (with `toIterable`) with the result of the `array_reverse`.
+
+## unique
+
+Internally, this method will call the PHP [array_unique](https://www.php.net/manual/en/function.array-unique.php) on the array representation of the collection (obtained via `toArray` method).
+
+Then it will create and return a new instance of the collection (with `toIterable`) with the result of the `array_unique`.
+
+## values
+
+Internally, this method is calling the PHP [array_values](https://www.php.net/manual/en/function.array-values.php) of the array held in the `ArrayIterator` (via the `ArrayIterator::getArrayCopy` method)

--- a/docs/convertible.md
+++ b/docs/convertible.md
@@ -1,6 +1,17 @@
 # Convertible
 
-The following interfaces are defined to easy the process of creating/converting collections/collection items to basic  PHP types.
+The following interfaces are defined to easy the process of creating/converting collections/collection items to basic PHP types.
+
+## fromIterable
+
+This interface defines how to create a collection item from an iterable:
+
+```php
+interface FromIterable
+{
+    public static function fromIterable(iterable $data): self|static;
+}
+```
 
 ## fromArray
 

--- a/docs/filterable-collection-trait.md
+++ b/docs/filterable-collection-trait.md
@@ -1,42 +1,24 @@
 # FilterableCollectionTrait
 
-This trait (which internally also uses the `CollectionTrait`) adds filtering capabilities to your collection.
+This trait (which internally also uses the `CollectionTrait`) adds filtering capabilities to your collection, by implementing the `FilterableCollection` interface.
 
 It provides the following methods to your collection:
 
 ## filter
 
-```php
-public function filter(CollectionFilter $filter): self|static
-```
+Internally, this method will create a new empty collection and then iterate through your collection:
 
-This will accept a `CollectionFilter` instance (with the definitions of the filter being applied to the collection), and returns a new collection with only the elements that have met the criteria defined in `$filter`.
+If each element is an implementation of `FilterItem` and that item matches the criteria of the `CollectionFilter` (by calling the `isSatisfiedBy` method) the item will be added to the result collection.  
 
 ## groupBy
 
-```php
-public function groupBy(bool $removeEmptyGroups, CollectionFilter ...$filters): array
-```
+Internally, this method will create an array and initialize the groups, where each group will have as the key the value returned by the `key` of each filter passed.
 
-This method allows you to apply a series of filters to a collection and group the result by each filter. The `$removeEmptyGroups` flag means if we will remove or keep groups in the result without items.
-
-The result is returned as an array with the following structure:
-
-```php
-[
-    'filter_1_key' => [
-        'item_key_1' => item object 1
-        ...
-        'item_key_N' => item object X
-     ],
-     'filter_2_key' => [
-     'item_key_1' => item object 1
-     ...
-     'item_key_N' => item object Y
-     ],
-     ...
-]
-```
+- Then it will iterate through your collection, and for each element it will iterate the filters.
+- If each element is an implementation of `FilterItem` and that element matches the criteria of the current filter (by calling the `isSatisfiedBy` method)
+  - The element will be added to the result array on the group key
+  - On the group it will have a key that is calculated by calling the `groupByKey` of the element
+- Finally, it will return the group array, optionally removing empty groups if the `$removeEmptyGroups` is set to `true`
 
 ## How to filter collections
 
@@ -49,7 +31,7 @@ interface FilterItem
 }
 ```
 
-In order to the use the `FilterableCollectionTrait`, the items on your collection must implement the `FilteItem` interface.
+In order to the use the `FilterableCollectionTrait`, the items on your collection must implement the `FilterItem` interface.
 
 Each item needs to implement the `groupByKey` method that will be used to group items. This method return the key of the group and will receive additional extra data that might be necessary in order to group the items.
 

--- a/src/AbstractCollection.php
+++ b/src/AbstractCollection.php
@@ -4,19 +4,17 @@ declare(strict_types=1);
 namespace Kununu\Collection;
 
 use ArrayIterator;
-use Kununu\Collection\Convertible\ToArray;
 
 /**
- * @method static self  fromIterable(iterable $data)
- * @method        self  add($value)
- * @method        self  unique()
- * @method        self  reverse()
- * @method        self  diff(self $other)
- * @method        self  each(callable $function, bool $rewind = true)
- * @method        array map(callable $function, bool $rewind = true)
- * @method        mixed reduce(callable $function, mixed $initial = null, bool $rewind = true)
+ * @method static self fromIterable(iterable $data)
+ * @method        self add(mixed $value)
+ * @method        self diff(Collection $other)
+ * @method        self duplicates(bool $strict = true, bool $uniques = false)
+ * @method        self each(callable $function, bool $rewind = true)
+ * @method        self reverse()
+ * @method        self unique()
  */
-abstract class AbstractCollection extends ArrayIterator implements ToArray
+abstract class AbstractCollection extends ArrayIterator implements Collection
 {
     use CollectionTrait;
 }

--- a/src/AbstractFilterableCollection.php
+++ b/src/AbstractFilterableCollection.php
@@ -4,21 +4,19 @@ declare(strict_types=1);
 namespace Kununu\Collection;
 
 use ArrayIterator;
-use Kununu\Collection\Convertible\ToArray;
 use Kununu\Collection\Filter\CollectionFilter;
 
 /**
- * @method static self  fromIterable(iterable $data)
- * @method        self  add($value)
- * @method        self  unique()
- * @method        self  reverse()
- * @method        self  diff(self $other)
- * @method        self  each(callable $function, bool $rewind = true)
- * @method        array map(callable $function, bool $rewind = true)
- * @method        mixed reduce(callable $function, mixed $initial = null, bool $rewind = true)
- * @method        self  filter(CollectionFilter $filter)
+ * @method static self fromIterable(iterable $data)
+ * @method        self add(mixed $value)
+ * @method        self diff(Collection $other)
+ * @method        self duplicates(bool $strict = true, bool $uniques = false)
+ * @method        self each(callable $function, bool $rewind = true)
+ * @method        self reverse()
+ * @method        self unique()
+ * @method        self filter(CollectionFilter $filter)
  */
-abstract class AbstractFilterableCollection extends ArrayIterator implements ToArray
+abstract class AbstractFilterableCollection extends ArrayIterator implements FilterableCollection
 {
     use FilterableCollectionTrait;
 }

--- a/src/AutoSortableOffsetSetTrait.php
+++ b/src/AutoSortableOffsetSetTrait.php
@@ -5,9 +5,10 @@ namespace Kununu\Collection;
 
 trait AutoSortableOffsetSetTrait
 {
-    public function offsetSet($key, $value): void
+    public function offsetSet(mixed $key, mixed $value): void
     {
         parent::offsetSet($key, $value);
+
         $this->ksort();
     }
 }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Collection;
+
+use Kununu\Collection\Convertible\FromIterable;
+use Kununu\Collection\Convertible\ToArray;
+
+interface Collection extends FromIterable, ToArray
+{
+    public function add(mixed $value): self|static;
+
+    public function diff(self $other): self|static;
+
+    public function duplicates(bool $strict = true, bool $uniques = false): self|static;
+
+    public function each(callable $function, bool $rewind = true): self|static;
+
+    public function empty(): bool;
+
+    public function has(mixed $value, bool $strict = true): bool;
+
+    public function keys(): array;
+
+    public function map(callable $function, bool $rewind = true): array;
+
+    public function reduce(callable $function, mixed $initial = null, bool $rewind = true): mixed;
+
+    public function reverse(): self|static;
+
+    public function unique(): self|static;
+
+    public function values(): array;
+}

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -42,6 +42,22 @@ trait CollectionTrait
         return static::fromIterable(array_unique($this->toArray(), SORT_REGULAR));
     }
 
+    public function duplicates(bool $strict = true): self|static
+    {
+        $elements = new static();
+        $duplicates = new static();
+
+        $this->each(function ($item) use (&$elements, &$duplicates, $strict): void {
+            if ($elements->has($item, $strict)) {
+                $duplicates->append($item);
+
+                return;
+            }
+            $elements->append($item);
+        });
+
+        return $duplicates;
+    }
     public function reverse(): self|static
     {
         return static::fromIterable(array_reverse($this->toArray()));

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -32,6 +32,11 @@ trait CollectionTrait
         return $this;
     }
 
+    public function has(mixed $value, bool $strict = true): bool
+    {
+        return in_array($value, $this->toArray(), $strict);
+    }
+
     public function unique(): self|static
     {
         return static::fromIterable(array_unique($this->toArray(), SORT_REGULAR));

--- a/src/Convertible/FromIterable.php
+++ b/src/Convertible/FromIterable.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Collection\Convertible;
+
+interface FromIterable
+{
+    public static function fromIterable(iterable $data): self|static;
+}

--- a/src/FilterableCollection.php
+++ b/src/FilterableCollection.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Collection;
+
+use Kununu\Collection\Filter\CollectionFilter;
+
+interface FilterableCollection extends Collection
+{
+    public function filter(CollectionFilter $filter): self|static;
+
+    public function groupBy(bool $removeEmptyGroups, CollectionFilter ...$filters): array;
+}

--- a/tests/AbstractItemTest.php
+++ b/tests/AbstractItemTest.php
@@ -26,31 +26,37 @@ final class AbstractItemTest extends TestCase
     {
         $item = new AbstractItemStub(['name' => 'My Name']);
 
-        $this->assertNull($item->getId());
-        $this->assertEquals('My Name', $item->getName());
-        $this->assertNull($item->getCreatedAt());
-        $this->assertNull($item->getSimpleName());
-        $this->assertNull($item->getVerified());
-        $this->assertNull($item->getIndustryId());
-        $this->assertNull($item->getSalary());
+        self::assertNull($item->getId());
+        self::assertEquals('My Name', $item->getName());
+        self::assertNull($item->getCreatedAt());
+        self::assertNull($item->getSimpleName());
+        self::assertNull($item->getVerified());
+        self::assertNull($item->getIndustryId());
+        self::assertNull($item->getSalary());
 
         $item->setId(100);
-        $this->assertSame(100, $item->getId());
+
+        self::assertSame(100, $item->getId());
 
         $item->setCreatedAt($createdAt = new DateTime());
-        $this->assertSame($createdAt, $item->getCreatedAt());
+
+        self::assertSame($createdAt, $item->getCreatedAt());
 
         $item->setSimpleName('Simple name');
-        $this->assertSame('Simple name', $item->getSimpleName());
+
+        self::assertSame('Simple name', $item->getSimpleName());
 
         $item->setVerified(true);
-        $this->assertTrue($item->getVerified());
+
+        self::assertTrue($item->getVerified());
 
         $item->setIndustryId(15);
-        $this->assertSame(15, $item->getIndustryId());
+
+        self::assertSame(15, $item->getIndustryId());
 
         $item->setSalary(1500.29);
-        $this->assertSame(1500.29, $item->getSalary());
+
+        self::assertSame(1500.29, $item->getSalary());
     }
 
     #[DataProvider('itemBuildDataProvider')]
@@ -66,16 +72,16 @@ final class AbstractItemTest extends TestCase
     ): void {
         $item = AbstractItemStub::build($data);
 
-        $this->assertSame($expectedId, $item->getId());
-        $this->assertNotNull($item->getId());
-        $this->assertSame($expectedName, $item->getName());
-        $this->assertEquals($expectedCreatedAt, $item->getCreatedAt());
-        $this->assertNull($item->getExtraFieldNotUsedInBuild());
-        $this->assertSame($expectedSimpleName, $item->getSimpleName());
-        $this->assertSame($expectedVerified, $item->getVerified());
-        $this->assertNotNull($item->getVerified());
-        $this->assertSame($expectedIndustryId, $item->getIndustryId());
-        $this->assertSame($expectedSalary, $item->getSalary());
+        self::assertSame($expectedId, $item->getId());
+        self::assertNotNull($item->getId());
+        self::assertSame($expectedName, $item->getName());
+        self::assertEquals($expectedCreatedAt, $item->getCreatedAt());
+        self::assertNull($item->getExtraFieldNotUsedInBuild());
+        self::assertSame($expectedSimpleName, $item->getSimpleName());
+        self::assertSame($expectedVerified, $item->getVerified());
+        self::assertNotNull($item->getVerified());
+        self::assertSame($expectedIndustryId, $item->getIndustryId());
+        self::assertSame($expectedSalary, $item->getSalary());
     }
 
     public static function itemBuildDataProvider(): array
@@ -169,13 +175,13 @@ final class AbstractItemTest extends TestCase
         $item = AbstractItemWithRequiredFieldsStub::build($data);
 
         if (null === $expectedExceptionMessage) {
-            $this->assertIsInt($item->giveMeTheId());
-            $this->assertIsString($item->giveMeTheName());
-            $this->assertInstanceOf(DateTime::class, $item->giveMeTheCreatedAt());
-            $this->assertIsBool($item->giveMeTheVerified());
-            $this->assertIsBool($item->giveMeTheVerified());
-            $this->assertInstanceOf(DTOStub::class, $item->giveMeTheCustom());
-            $this->assertIsFloat($item->giveMeTheScore());
+            self::assertIsInt($item->giveMeTheId());
+            self::assertIsString($item->giveMeTheName());
+            self::assertInstanceOf(DateTime::class, $item->giveMeTheCreatedAt());
+            self::assertIsBool($item->giveMeTheVerified());
+            self::assertIsBool($item->giveMeTheVerified());
+            self::assertInstanceOf(DTOStub::class, $item->giveMeTheCustom());
+            self::assertIsFloat($item->giveMeTheScore());
         }
     }
 
@@ -252,13 +258,13 @@ final class AbstractItemTest extends TestCase
             'fromArray' => ['id' => 1, 'name' => 'The Name'],
         ]);
 
-        $this->assertInstanceOf(FromArrayStub::class, $item->fromArray());
-        $this->assertEquals(1, $item->fromArray()->id);
-        $this->assertEquals('The Name', $item->fromArray()->name);
-        $this->assertNull($item->notFromArray());
-        $this->assertInstanceOf(FromArrayStub::class, $item->defaultFromArray());
-        $this->assertEquals(0, $item->defaultFromArray()->id);
-        $this->assertEquals('', $item->defaultFromArray()->name);
+        self::assertInstanceOf(FromArrayStub::class, $item->fromArray());
+        self::assertEquals(1, $item->fromArray()->id);
+        self::assertEquals('The Name', $item->fromArray()->name);
+        self::assertNull($item->notFromArray());
+        self::assertInstanceOf(FromArrayStub::class, $item->defaultFromArray());
+        self::assertEquals(0, $item->defaultFromArray()->id);
+        self::assertEquals('', $item->defaultFromArray()->name);
     }
 
     public function testItemBuildCollection(): void
@@ -271,9 +277,9 @@ final class AbstractItemTest extends TestCase
             ],
         ]);
 
-        $this->assertInstanceOf(DTOCollectionStub::class, $item->collection());
-        $this->assertCount(3, $item->collection());
-        $this->assertSame(
+        self::assertInstanceOf(DTOCollectionStub::class, $item->collection());
+        self::assertCount(3, $item->collection());
+        self::assertSame(
             [
                 'field 1' => [
                     'field' => 'field 1',
@@ -290,9 +296,9 @@ final class AbstractItemTest extends TestCase
             ],
             $item->collection()->toArray()
         );
-        $this->assertNull($item->notCollection());
-        $this->assertInstanceOf(DTOCollectionStub::class, $item->defaultCollection());
-        $this->assertEmpty($item->defaultCollection());
+        self::assertNull($item->notCollection());
+        self::assertInstanceOf(DTOCollectionStub::class, $item->defaultCollection());
+        self::assertEmpty($item->defaultCollection());
     }
 
     #[DataProvider('itemBuildConditionalDataProvider')]
@@ -303,7 +309,7 @@ final class AbstractItemTest extends TestCase
             'value'  => 12.5,
         ]);
 
-        $this->assertSame($expected, $item->value());
+        self::assertSame($expected, $item->value());
     }
 
     public static function itemBuildConditionalDataProvider(): array
@@ -324,6 +330,7 @@ final class AbstractItemTest extends TestCase
         $this->expectExceptionMessage(
             'Kununu\Collection\Tests\Stub\AbstractItemStub: Invalid method "thisMethodReallyDoesNotExists" called'
         );
+
         $item->thisMethodReallyDoesNotExists();
     }
 
@@ -335,6 +342,7 @@ final class AbstractItemTest extends TestCase
         $this->expectExceptionMessage(
             'Kununu\Collection\Tests\Stub\AbstractItemStub : Invalid attribute "invalidProperty"'
         );
+
         $item->setInvalidProperty(true);
     }
 
@@ -346,6 +354,7 @@ final class AbstractItemTest extends TestCase
         $this->expectExceptionMessage(
             'Kununu\Collection\Tests\Stub\AbstractItemStub : Invalid attribute "invalidProperty"'
         );
+
         $item->getInvalidProperty(true);
     }
 
@@ -357,6 +366,7 @@ final class AbstractItemTest extends TestCase
         $this->expectExceptionMessage(
             'Kununu\Collection\Tests\Stub\AbstractItemStub: Invalid method "withInvalidProperty" called'
         );
+
         $item->withInvalidProperty(false);
     }
 
@@ -377,27 +387,27 @@ final class AbstractItemTest extends TestCase
             'required_date_time_immutable_field' => '2023-10-11 12:34:04',
         ]);
 
-        $this->assertEquals('The string field', $item->stringField());
-        $this->assertEquals('The required string field', $item->requiredStringField());
-        $this->assertTrue($item->boolField());
-        $this->assertFalse($item->requiredBoolField());
-        $this->assertEquals(1, $item->intField());
-        $this->assertEquals(2, $item->requiredIntField());
-        $this->assertEquals(1.5, $item->floatField());
-        $this->assertEquals(2.6, $item->requiredFloatField());
-        $this->assertEquals(
+        self::assertEquals('The string field', $item->stringField());
+        self::assertEquals('The required string field', $item->requiredStringField());
+        self::assertTrue($item->boolField());
+        self::assertFalse($item->requiredBoolField());
+        self::assertEquals(1, $item->intField());
+        self::assertEquals(2, $item->requiredIntField());
+        self::assertEquals(1.5, $item->floatField());
+        self::assertEquals(2.6, $item->requiredFloatField());
+        self::assertEquals(
             DateTime::createFromFormat('Y-m-d H:i:s', '2023-10-11 12:34:01'),
             $item->dateTimeField()
         );
-        $this->assertEquals(
+        self::assertEquals(
             DateTime::createFromFormat('Y-m-d H:i:s', '2023-10-11 12:34:02'),
             $item->requiredDateTimeField()
         );
-        $this->assertEquals(
+        self::assertEquals(
             DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2023-10-11 12:34:03'),
             $item->dateTimeImmutableField()
         );
-        $this->assertEquals(
+        self::assertEquals(
             DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2023-10-11 12:34:04'),
             $item->requiredDateTimeImmutableField()
         );

--- a/tests/AbstractItemToArrayTest.php
+++ b/tests/AbstractItemToArrayTest.php
@@ -21,7 +21,7 @@ final class AbstractItemToArrayTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'id'         => 50,
                 'name'       => '1000: My Name is?',

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -222,6 +222,148 @@ final class CollectionTest extends TestCase
         $this->assertEquals([1, 2, 3, 4], $uniqueCollection->toArray());
     }
 
+    public static function duplicatesDataProvider(): array
+    {
+        return [
+            'integers_no_duplicates_strict' => [
+                true,
+                [1, 2, 3],
+                []
+            ],
+            'integers_duplicates_strict' => [
+                true,
+                [1, 2, 3, 4, 1, 2, 4],
+                [1, 2, 4],
+            ],
+            'integers_duplicates_strict_mixed' => [
+                true,
+                [1, 2, 3, 4, 1, '2', 4],
+                [1, 4],
+            ],
+            'strings_no_duplicates_strict' => [
+                true,
+                [
+                    '7178e84e-472d-4766-8e45-a571871ff988',
+                    'ca583de8-e6ba-4098-a0bf-10c981ff3d8d',
+                    '909a8214-86b1-4d78-94f2-6a8e22a24020',
+                    'baaeace4-1aeb-4b47-ac2c-4b90ebd12342',
+                ],
+                [],
+            ],
+            'strings_duplicates_strict' => [
+                true,
+                [
+                    '7178e84e-472d-4766-8e45-a571871ff988',
+                    '7178e84e-472d-4766-8e45-a571871ff988', // dup 1-1
+                    '7178e84e-472d-4766-8e45-a571871ff988', // dup 1-2
+                    'ca583de8-e6ba-4098-a0bf-10c981ff3d8d',
+                    'ca583de8-e6ba-4098-a0bf-10c981ff3d8d', // dup 2-1
+                    '909a8214-86b1-4d78-94f2-6a8e22a24020',
+                    'baaeace4-1aeb-4b47-ac2c-4b90ebd12342',
+                ],
+                [
+                    '7178e84e-472d-4766-8e45-a571871ff988', // dup 1-1
+                    '7178e84e-472d-4766-8e45-a571871ff988', // dup 1-2
+                    'ca583de8-e6ba-4098-a0bf-10c981ff3d8d', // dup 2-1
+                ],
+            ],
+            'item_stubs_no_duplicates_strict' => [
+                true,
+                [
+                    new AbstractItemStub(['name' => 'one']),
+                    new AbstractItemStub(['name' => 'two']),
+                    new AbstractItemStub(['name' => 'three']),
+                ],
+                [],
+            ],
+            'item_stubs_duplicates_strict' => [
+                true,
+                [
+                    $one = new AbstractItemStub(['name' => 'one']),
+                    $one,
+                    $two = new AbstractItemStub(['name' => 'two']),
+                    $two,
+                    new AbstractItemStub(['name' => 'three']),
+                ],
+                [
+                    $one,
+                    $two,
+                ],
+            ],
+            'integers_no_duplicates_loose' => [
+                false,
+                [1, 2, 3],
+                []
+            ],
+            'integers_duplicates_loose' => [
+                false,
+                [1, 2, 3, 4, 1, '2', 4],
+                ['1', 2, '4'],
+            ],
+            'strings_no_duplicates_loose' => [
+                false,
+                [
+                    '7178e84e-472d-4766-8e45-a571871ff988',
+                    'ca583de8-e6ba-4098-a0bf-10c981ff3d8d',
+                    '909a8214-86b1-4d78-94f2-6a8e22a24020',
+                    'baaeace4-1aeb-4b47-ac2c-4b90ebd12342',
+                ],
+                [],
+            ],
+            'strings_duplicates_loose' => [
+                false,
+                [
+                    '7178e84e-472d-4766-8e45-a571871ff988',
+                    '7178e84e-472d-4766-8e45-a571871ff988', // dup 1-1
+                    '7178e84e-472d-4766-8e45-a571871ff988', // dup 1-2
+                    'ca583de8-e6ba-4098-a0bf-10c981ff3d8d',
+                    'ca583de8-e6ba-4098-a0bf-10c981ff3d8d', // dup 2-1
+                    '909a8214-86b1-4d78-94f2-6a8e22a24020',
+                    'baaeace4-1aeb-4b47-ac2c-4b90ebd12342',
+                    '2',
+                    2
+                ],
+                [
+                    '7178e84e-472d-4766-8e45-a571871ff988', // dup 1-1
+                    '7178e84e-472d-4766-8e45-a571871ff988', // dup 1-2
+                    'ca583de8-e6ba-4098-a0bf-10c981ff3d8d', // dup 2-1
+                    2
+                ],
+            ],
+            'item_stubs_no_duplicates_loose' => [
+                false,
+                [
+                    new AbstractItemStub(['name' => 'one']),
+                    new AbstractItemStub(['name' => 'two']),
+                    new AbstractItemStub(['name' => 'three']),
+                ],
+                [],
+            ],
+            'item_stubs_duplicates_loose' => [
+                false,
+                [
+                    new AbstractItemStub(['name' => 'one']),
+                    new AbstractItemStub(['name' => 'one']),
+                    new AbstractItemStub(['name' => 'two']),
+                    new AbstractItemStub(['name' => 'two']),
+                    new AbstractItemStub(['name' => 'three']),
+                ],
+                [
+                    new AbstractItemStub(['name' => 'one']),
+                    new AbstractItemStub(['name' => 'two']),
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('duplicatesDataProvider')]
+    public function testDuplicates(bool $strict, array $contents, array $expected): void
+    {
+        $collection = CollectionStub::fromIterable($contents);
+        $duplicateCollection = $collection->duplicates($strict);
+        $this->assertEquals($expected, $duplicateCollection->toArray());
+    }
+
     public function testReverse(): void
     {
         $this->assertEquals([5, 4, 3, 2, 1], CollectionStub::fromIterable([1, 2, 3, 4, 5])->reverse()->toArray());

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -6,6 +6,7 @@ namespace Kununu\Collection\Tests;
 use ArrayIterator;
 use Exception;
 use Generator;
+use Kununu\Collection\Tests\Stub\AbstractItemStub;
 use Kununu\Collection\Tests\Stub\AutoSortedCollectionStub;
 use Kununu\Collection\Tests\Stub\CollectionStub;
 use Kununu\Collection\Tests\Stub\ToArrayStub;
@@ -92,6 +93,108 @@ final class CollectionTest extends TestCase
                     '3: GHI',
                     '4: JKL',
                 ],
+            ],
+        ];
+    }
+
+    #[DataProvider('hasDataProvider')]
+    public function testHas(iterable $collectionContents, mixed $hasValue, bool $hasStrict, bool $expectedHas): void
+    {
+        $collection = CollectionStub::fromIterable($collectionContents);
+
+        $this->assertEquals($expectedHas, $collection->has($hasValue, $hasStrict));
+    }
+
+    public static function hasDataProvider(): array
+    {
+        return [
+            'has_with_integers_strict' => [
+                [1, 2, 3],
+                1,
+                true,
+                true,
+            ],
+            'has_with_integers_loose' => [
+                [1, 2, 3],
+                '1',
+                false,
+                true,
+            ],
+            'missing_with_integers_strict' => [
+                [1, 2, 3],
+                4,
+                true,
+                false,
+            ],
+            'missing_with_integers_strict_string_to_int' => [
+                [1, 2, 3],
+                '1',
+                true,
+                false,
+            ],
+            'has_with_strings_strict' => [
+                ['one', 'two', 'three'],
+                'one',
+                true,
+                true,
+            ],
+            'missing_with_strings_strict' => [
+                ['one', 'two', 'three'],
+                'missing',
+                true,
+                false,
+            ],
+            'has_with_strings_loose' => [
+                ['one', 'two', 'three'],
+                'one',
+                false,
+                true,
+            ],
+            'missing_with_strings_loose' => [
+                ['one', 'two', 'three'],
+                'missing',
+                false,
+                false,
+            ],
+            'has_with_object_strict' => [
+                [
+                    $one = new AbstractItemStub(['name' => 'one']),
+                    new AbstractItemStub(['name' => 'two']),
+                    new AbstractItemStub(['name' => 'three']),
+                ],
+                $one,
+                true,
+                true,
+            ],
+            'missing_with_object_strict' => [
+                [
+                    new AbstractItemStub(['name' => 'one']),
+                    new AbstractItemStub(['name' => 'two']),
+                    new AbstractItemStub(['name' => 'three']),
+                ],
+                new AbstractItemStub(['name' => 'one']),
+                true,
+                false,
+            ],
+            'has_with_object_loose' => [
+                [
+                    new AbstractItemStub(['name' => 'one']),
+                    new AbstractItemStub(['name' => 'two']),
+                    new AbstractItemStub(['name' => 'three']),
+                ],
+                new AbstractItemStub(['name' => 'one']),
+                false,
+                true,
+            ],
+            'missing_with_object_loose' => [
+                [
+                    new AbstractItemStub(['name' => 'one']),
+                    new AbstractItemStub(['name' => 'two']),
+                    new AbstractItemStub(['name' => 'three']),
+                ],
+                new AbstractItemStub(['name' => 'vier']),
+                false,
+                false,
             ],
         ];
     }

--- a/tests/Filter/FilterOperatorAndTest.php
+++ b/tests/Filter/FilterOperatorAndTest.php
@@ -12,11 +12,11 @@ final class FilterOperatorAndTest extends TestCase
     {
         $operator = new FilterOperatorAnd();
 
-        $this->assertTrue($operator->initialValue());
-        $this->assertFalse($operator->exitConditionValue());
-        $this->assertTrue($operator->calculate(true, true));
-        $this->assertFalse($operator->calculate(false, false));
-        $this->assertFalse($operator->calculate(true, false));
-        $this->assertFalse($operator->calculate(false, true));
+        self::assertTrue($operator->initialValue());
+        self::assertFalse($operator->exitConditionValue());
+        self::assertTrue($operator->calculate(true, true));
+        self::assertFalse($operator->calculate(false, false));
+        self::assertFalse($operator->calculate(true, false));
+        self::assertFalse($operator->calculate(false, true));
     }
 }

--- a/tests/Filter/FilterOperatorOrTest.php
+++ b/tests/Filter/FilterOperatorOrTest.php
@@ -12,11 +12,11 @@ final class FilterOperatorOrTest extends TestCase
     {
         $operator = new FilterOperatorOr();
 
-        $this->assertFalse($operator->initialValue());
-        $this->assertTrue($operator->exitConditionValue());
-        $this->assertFalse($operator->calculate(false, false));
-        $this->assertTrue($operator->calculate(true, true));
-        $this->assertTrue($operator->calculate(true, false));
-        $this->assertTrue($operator->calculate(false, true));
+        self::assertFalse($operator->initialValue());
+        self::assertTrue($operator->exitConditionValue());
+        self::assertFalse($operator->calculate(false, false));
+        self::assertTrue($operator->calculate(true, true));
+        self::assertTrue($operator->calculate(true, false));
+        self::assertTrue($operator->calculate(false, true));
     }
 }

--- a/tests/Filter/FilterOperatorXOrTest.php
+++ b/tests/Filter/FilterOperatorXOrTest.php
@@ -12,11 +12,11 @@ final class FilterOperatorXOrTest extends TestCase
     {
         $operator = new FilterOperatorXor();
 
-        $this->assertFalse($operator->initialValue());
-        $this->assertTrue($operator->exitConditionValue());
-        $this->assertFalse($operator->calculate(false, false));
-        $this->assertFalse($operator->calculate(true, true));
-        $this->assertTrue($operator->calculate(true, false));
-        $this->assertTrue($operator->calculate(false, true));
+        self::assertFalse($operator->initialValue());
+        self::assertTrue($operator->exitConditionValue());
+        self::assertFalse($operator->calculate(false, false));
+        self::assertFalse($operator->calculate(true, true));
+        self::assertTrue($operator->calculate(true, false));
+        self::assertTrue($operator->calculate(false, true));
     }
 }

--- a/tests/FilterableCollectionTest.php
+++ b/tests/FilterableCollectionTest.php
@@ -38,12 +38,12 @@ final class FilterableCollectionTest extends TestCase
 
         $filteredCollection = $collection->filter($filter);
 
-        $this->assertCount(2, $filteredCollection);
+        self::assertCount(2, $filteredCollection);
         foreach ($filteredCollection as $item) {
-            $this->assertInstanceOf(FilterItemStub::class, $item);
+            self::assertInstanceOf(FilterItemStub::class, $item);
         }
-        $this->assertEquals('a', $filteredCollection[0]->groupByKey());
-        $this->assertEquals('c', $filteredCollection[1]->groupByKey());
+        self::assertEquals('a', $filteredCollection[0]->groupByKey());
+        self::assertEquals('c', $filteredCollection[1]->groupByKey());
 
         $collection = (new FilterableCollectionStub())
             ->add(1)
@@ -51,7 +51,7 @@ final class FilterableCollectionTest extends TestCase
             ->add(new FilterItemStub('d'))
             ->add('a string');
 
-        $this->assertEmpty($collection->filter($filter));
+        self::assertEmpty($collection->filter($filter));
     }
 
     public function testGroupBy(): void
@@ -119,19 +119,20 @@ final class FilterableCollectionTest extends TestCase
 
         $groups = $collection->groupBy(false, $filter1, $filter2, $filter3, $filter4, $filter5, $filter6);
 
-        $this->assertCount(6, $groups);
-        $this->assertCount(1, $groups['Filter 1']);
-        $this->assertCount(1, $groups['Filter 2']);
-        $this->assertCount(1, $groups['Filter 3']);
-        $this->assertEmpty($groups['Filter 4']);
-        $this->assertCount(2, $groups['Filter 5']);
-        $this->assertEmpty($groups['Filter 6']);
+        self::assertCount(6, $groups);
+        self::assertCount(1, $groups['Filter 1']);
+        self::assertCount(1, $groups['Filter 2']);
+        self::assertCount(1, $groups['Filter 3']);
+        self::assertEmpty($groups['Filter 4']);
+        self::assertCount(2, $groups['Filter 5']);
+        self::assertEmpty($groups['Filter 6']);
 
         $groups = $collection->groupBy(true, $filter1, $filter2, $filter3, $filter4, $filter5, $filter6);
-        $this->assertCount(4, $groups);
-        $this->assertCount(1, $groups['Filter 1']);
-        $this->assertCount(1, $groups['Filter 2']);
-        $this->assertCount(1, $groups['Filter 3']);
-        $this->assertCount(2, $groups['Filter 5']);
+
+        self::assertCount(4, $groups);
+        self::assertCount(1, $groups['Filter 1']);
+        self::assertCount(1, $groups['Filter 2']);
+        self::assertCount(1, $groups['Filter 3']);
+        self::assertCount(2, $groups['Filter 5']);
     }
 }

--- a/tests/Mapper/DefaultMapperTest.php
+++ b/tests/Mapper/DefaultMapperTest.php
@@ -16,7 +16,7 @@ final class DefaultMapperTest extends TestCase
     {
         $mapper = new MapperStub(DTOCollectionStub::class);
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'key 1' => 100,
                 'key 2' => 101,
@@ -42,6 +42,6 @@ final class DefaultMapperTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid collection class: Kununu\Collection\Tests\Stub\CollectionStub');
 
-        $this->assertNull(new MapperStub(CollectionStub::class));
+        self::assertNull(new MapperStub(CollectionStub::class));
     }
 }

--- a/tests/Stub/DTOCollectionStub.php
+++ b/tests/Stub/DTOCollectionStub.php
@@ -6,16 +6,6 @@ namespace Kununu\Collection\Tests\Stub;
 use InvalidArgumentException;
 use Kununu\Collection\AbstractCollection;
 
-/**
- * @method static self  fromIterable(iterable $data)
- * @method        self  add($value)
- * @method        self  unique()
- * @method        self  reverse()
- * @method        self  diff(self $other)
- * @method        self  each(callable $function, bool $rewind = true)
- * @method        array map(callable $function, bool $rewind = true)
- * @method        mixed reduce(callable $function, mixed $initial = null, bool $rewind = true)
- */
 final class DTOCollectionStub extends AbstractCollection
 {
     private const INVALID = 'Can only append array or %s';

--- a/tests/Stub/StringableStub.php
+++ b/tests/Stub/StringableStub.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Collection\Tests\Stub;
+
+final class StringableStub
+{
+    private function __construct(private readonly ToIntStub $id, private readonly string $value)
+    {
+    }
+
+    public static function create(ToIntStub $id, string $value): self
+    {
+        return new self($id, $value);
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('%d: %s', $this->id->toInt(), $this->value);
+    }
+}


### PR DESCRIPTION
# Description

The objective of this PR is to introduce interfaces to define methods for the collections (regular and filtered).

## Details
-  Define interfaces for collections
- Create `FromIterable` interface
- Change `AbstractCollection` and `AbstractFilterableCollection` to implement the interfaces
- Allow `duplicates` to return only unique values
- Add `keys` and `values` method to collections
- Fix tests
- Add tests for new code
- Update documentation

This PR also cherry-picked https://github.com/kununu/collections/pull/32 and https://github.com/kununu/collections/pull/33 that introduce the `has` and `duplicates` methods on the collections (Thanks @tdashton)