### PR TITLE
Add chunk to collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ composer test-coverage
 To run tests in a docker container (without coverage):
 
 ```bash
-docker run -it --rm --workdir /app --volume .:/app php:8.1 php vendor/bin/phpunit tests/                                                     1 ↵
+docker run -it --rm --workdir /app --volume .:/app php:8.1 php vendor/bin/phpunit tests/
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ composer install
 composer test-coverage
 ```
 
+To run tests in a docker container (without coverage):
+
+```bash
+docker run -it --rm --workdir /app --volume .:/app php:8.1 php vendor/bin/phpunit tests/                                                     1 ↵
+```
+
 ## Usage
 
 The library defines interfaces to deal with collections and also boilerplate code with default implementations.

--- a/README.md
+++ b/README.md
@@ -33,12 +33,6 @@ composer install
 composer test-coverage
 ```
 
-To run tests in a docker container (without coverage):
-
-```bash
-docker run -it --rm --workdir /app --volume .:/app php:8.1 php vendor/bin/phpunit tests/
-```
-
 ## Usage
 
 The library defines interfaces to deal with collections and also boilerplate code with default implementations.

--- a/docs/collection-interfaces.md
+++ b/docs/collection-interfaces.md
@@ -92,7 +92,13 @@ function(mixed $element, string|float|int|bool|null $elementKey): void;
 public function eachChunk(int $size, callable $function): self|static
 ```
 
-This method chunks the collection and executes the given anonymous function with each chunk.
+This method chunks the collection using the passed `$size` and executes the given anonymous function with each chunk.
+
+Callable signature:
+
+```php
+function(CollectionInterface $collection): void;
+```
 
 ### empty
 

--- a/docs/collection-interfaces.md
+++ b/docs/collection-interfaces.md
@@ -44,6 +44,15 @@ This method is defined to be a fluent version of `ArrayIterator::append`. To do 
 $collection->add($item1)->add($item2);
 ```
 
+### chunk
+
+```php
+    /** @return self[]|static[] */
+    public function chunk(int $size): array
+```
+
+This method [mirrors the behavior of `array_chunk`](https://www.php.net/manual/function.array-chunk.php) and returns a zero indexed numeric array of the current Collection based on the chunk size provided.
+
 ### diff
 
 ```php
@@ -76,6 +85,14 @@ Callable signature:
 ```php
 function(mixed $element, string|float|int|bool|null $elementKey): void;
 ```
+
+### eachChunk
+
+```php
+public function eachChunk(int $size, callable $function): self|static
+```
+
+This method chunks the collection and executes the given anonymous function with each chunk.
 
 ### empty
 

--- a/docs/collection-interfaces.md
+++ b/docs/collection-interfaces.md
@@ -47,8 +47,8 @@ $collection->add($item1)->add($item2);
 ### chunk
 
 ```php
-    /** @return self[]|static[] */
-    public function chunk(int $size): array
+/** @return self[]|static[] */
+public function chunk(int $size): array
 ```
 
 This method [mirrors the behavior of `array_chunk`](https://www.php.net/manual/function.array-chunk.php) and returns a zero indexed numeric array of the current Collection based on the chunk size provided.

--- a/docs/collection-interfaces.md
+++ b/docs/collection-interfaces.md
@@ -51,7 +51,7 @@ $collection->add($item1)->add($item2);
 public function chunk(int $size): array
 ```
 
-This method [mirrors the behavior of `array_chunk`](https://www.php.net/manual/function.array-chunk.php) and returns a zero indexed numeric array of the current Collection based on the chunk size provided.
+This method [mirrors the behavior of `array_chunk`](https://www.php.net/manual/function.array-chunk.php) and returns a zero indexed numeric array of the current collection based on the chunk size provided.
 
 ### diff
 

--- a/docs/collection-trait.md
+++ b/docs/collection-trait.md
@@ -97,7 +97,7 @@ Internally it is call the `ArrayIterator::append` and returning the instance to 
 
 ## chunk
 
-This method [mirrors the behavior of `array_chunk`](https://www.php.net/manual/function.array-chunk.php) and returns a zero indexed numeric array of the current Collection based on the chunk size provided.
+Internally this method chunks [a copy](https://www.php.net/manual/arrayobject.getarraycopy.php) of the collection with the [`array_chunk` php function](https://www.php.net/manual/function.array-chunk.php), returning a zero indexed array of collections of the same type as the initial one.
 
 ## diff
 
@@ -123,7 +123,7 @@ Internally, this method will iterate through each item of a collection, optional
 
 ## eachChunk
 
-This method chunks the collection and executes the given anonymous function with each chunk.
+Internally, this method calls the [chunk](#chunk) function and then executes the passed anonymous function with each chunk.
 
 ## empty
 

--- a/docs/collection-trait.md
+++ b/docs/collection-trait.md
@@ -95,7 +95,7 @@ $collection->toArray();
 
 Internally it is call the `ArrayIterator::append` and returning the instance to allow fluent calls.
 
-### chunk
+## chunk
 
 This method [mirrors the behavior of `array_chunk`](https://www.php.net/manual/function.array-chunk.php) and returns a zero indexed numeric array of the current Collection based on the chunk size provided.
 
@@ -121,7 +121,7 @@ Finally, it will return the duplicated collection, optionally calling the `uniqu
 
 Internally, this method will iterate through each item of a collection, optionally rewind it at the end of the iteration, calling the anonymous function for each element.
 
-### eachChunk
+## eachChunk
 
 This method chunks the collection and executes the given anonymous function with each chunk.
 

--- a/docs/collection-trait.md
+++ b/docs/collection-trait.md
@@ -97,7 +97,7 @@ Internally it is call the `ArrayIterator::append` and returning the instance to 
 
 ## chunk
 
-Internally this method chunks [a copy](https://www.php.net/manual/arrayobject.getarraycopy.php) of the collection with the [`array_chunk` php function](https://www.php.net/manual/function.array-chunk.php), returning a zero indexed array of collections of the same type as the initial one.
+Internally this method chunks the collection (by getting a copy with [getArrayCopy](https://www.php.net/manual/en/arrayiterator.getarraycopy.php) method) with the PHP [array_chunk](https://www.php.net/manual/function.array-chunk.php) function, returning a zero indexed array of collections of the same type as the initial one.
 
 ## diff
 

--- a/docs/collection-trait.md
+++ b/docs/collection-trait.md
@@ -95,6 +95,10 @@ $collection->toArray();
 
 Internally it is call the `ArrayIterator::append` and returning the instance to allow fluent calls.
 
+### chunk
+
+This method [mirrors the behavior of `array_chunk`](https://www.php.net/manual/function.array-chunk.php) and returns a zero indexed numeric array of the current Collection based on the chunk size provided.
+
 ## diff
 
 To check the difference between two collections first it checks that the other collection is of the same type as the current one.
@@ -116,6 +120,10 @@ Finally, it will return the duplicated collection, optionally calling the `uniqu
 ## each
 
 Internally, this method will iterate through each item of a collection, optionally rewind it at the end of the iteration, calling the anonymous function for each element.
+
+### eachChunk
+
+This method chunks the collection and executes the given anonymous function with each chunk.
 
 ## empty
 

--- a/docs/collection-trait.md
+++ b/docs/collection-trait.md
@@ -123,7 +123,7 @@ Internally, this method will iterate through each item of a collection, optional
 
 ## eachChunk
 
-Internally, this method calls the [chunk](#chunk) function and then executes the passed anonymous function with each chunk.
+Internally, this method calls the [chunk](#chunk) method and then executes the passed anonymous function with each chunk.
 
 ## empty
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -10,11 +10,16 @@ interface Collection extends FromIterable, ToArray
 {
     public function add(mixed $value): self|static;
 
+    /** @return self[]|static[] */
+    public function chunk(int $size): array;
+
     public function diff(self $other): self|static;
 
     public function duplicates(bool $strict = true, bool $uniques = false): self|static;
 
     public function each(callable $function, bool $rewind = true): self|static;
+
+    public function eachChunk(int $size, callable $function): self|static;
 
     public function empty(): bool;
 

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -42,8 +42,8 @@ trait CollectionTrait
         }
 
         return array_map(
-            static function(array $uuids) {
-                return self::fromIterable($uuids);
+            static function(array $chunk) {
+                return self::fromIterable($chunk);
             },
             array_chunk($this->toArray(), $size)
         );

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -43,7 +43,7 @@ trait CollectionTrait
 
         return array_map(
             static fn(array $chunk) => self::fromIterable($chunk),
-            array_chunk($this->toArray(), $size)
+            array_chunk($this->getArrayCopy(), $size)
         );
     }
 

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -42,9 +42,7 @@ trait CollectionTrait
         }
 
         return array_map(
-            static function(array $chunk) {
-                return self::fromIterable($chunk);
-            },
+            static fn(array $chunk) => self::fromIterable($chunk),
             array_chunk($this->toArray(), $size)
         );
     }

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -34,6 +34,21 @@ trait CollectionTrait
         return $this;
     }
 
+    /** @return self[] */
+    public function chunk(int $size): array
+    {
+        if ($size < 1) {
+            return [$this];
+        }
+
+        return array_map(
+            static function(array $uuids) {
+                return self::fromIterable($uuids);
+            },
+            array_chunk($this->toArray(), $size)
+        );
+    }
+
     public function diff(Collection $other): self|static
     {
         if (!$other instanceof static) {
@@ -79,6 +94,15 @@ trait CollectionTrait
             if ($rewind) {
                 $this->rewind();
             }
+        }
+
+        return $this;
+    }
+
+    public function eachChunk(int $size, callable $function): self|static
+    {
+        foreach ($this->chunk($size) as $chunk) {
+            $function($chunk);
         }
 
         return $this;

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -486,11 +486,11 @@ final class CollectionTest extends TestCase
     }
 
     #[DataProvider('chunkDataProvider')]
-    public function testChunk(Collection $collectionToChunk, int $chunkSize, array $expectedChunks): void
+    public function testChunk(Collection $collection, int $chunkSize, array $expectedChunks): void
     {
         self::assertEquals(
             $expectedChunks,
-            $collectionToChunk->chunk($chunkSize)
+            $collection->chunk($chunkSize)
         );
     }
 
@@ -603,14 +603,16 @@ final class CollectionTest extends TestCase
     }
 
     #[DataProvider('chunkEachDataProvider')]
-    public function testChunkEach(Collection $collectionToChunk, int $chunkSize, array $expectedChunks): void
+    public function testChunkEach(Collection $collection, int $chunkSize, array $expectedChunks): void
     {
-        $expectedLambda = function(CollectionStub $collection) use ($expectedChunks): void {
-            static $i = 0;
-            self::assertEquals($collection, $expectedChunks[$i++]);
-        };
+        $i = 0;
 
-        $collectionToChunk->eachChunk($chunkSize, $expectedLambda);
+        $collection->eachChunk(
+            $chunkSize,
+            function(CollectionStub $collection) use (&$i, $expectedChunks): void {
+                self::assertEquals($collection, $expectedChunks[$i++]);
+            }
+        );
     }
 
     public static function chunkEachDataProvider(): array

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -615,9 +615,6 @@ final class CollectionTest extends TestCase
 
     public static function chunkEachDataProvider(): array
     {
-        $expectedFunction = static function(CollectionStub $stub): void {
-        };
-
         return [
             'chunk_each_size_0' => [
                 CollectionStub::fromIterable([1, 2, 3, 4, 5]),

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -602,6 +602,60 @@ final class CollectionTest extends TestCase
         ];
     }
 
+    #[DataProvider('chunkEachDataProvider')]
+    public function testChunkEach(Collection $collectionToChunk, int $chunkSize, array $expectedChunks): void
+    {
+        $expectedLambda = function(CollectionStub $collection) use ($expectedChunks): void {
+            static $i = 0;
+            self::assertEquals($collection, $expectedChunks[$i++]);
+        };
+
+        $collectionToChunk->eachChunk($chunkSize, $expectedLambda);
+    }
+
+    public static function chunkEachDataProvider(): array
+    {
+        $expectedFunction = static function(CollectionStub $stub): void {
+        };
+
+        return [
+            'chunk_each_size_0' => [
+                CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                0,
+                [
+                    CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                ],
+            ],
+            'chunk_each_size_2' => [
+                CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                2,
+                [
+                    CollectionStub::fromIterable([1, 2]),
+                    CollectionStub::fromIterable([3, 4]),
+                    CollectionStub::fromIterable([5]),
+                ],
+            ],
+            'chunk_each_size_1' => [
+                CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                1,
+                [
+                    CollectionStub::fromIterable([1]),
+                    CollectionStub::fromIterable([2]),
+                    CollectionStub::fromIterable([3]),
+                    CollectionStub::fromIterable([4]),
+                    CollectionStub::fromIterable([5]),
+                ],
+            ],
+            'chunk_each_size_5' => [
+                CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                5,
+                [
+                    CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                ],
+            ],
+        ];
+    }
+
     #[DataProvider('mapDataProvider')]
     public function testMap(bool $rewind, ?array $expectedCurrent, bool $expectException): void
     {

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -485,6 +485,55 @@ final class CollectionTest extends TestCase
         self::assertEquals([5, 4, 3, 2, 1], CollectionStub::fromIterable([1, 2, 3, 4, 5])->reverse()->toArray());
     }
 
+    #[DataProvider('chunkDataProvider')]
+    public function testChunk(Collection $collectionToChunk, int $chunkSize, array $expectedChunks): void
+    {
+        self::assertEquals(
+            $expectedChunks,
+            $collectionToChunk->chunk($chunkSize)
+        );
+    }
+
+    public static function chunkDataProvider(): array
+    {
+        return [
+            'chunk_size_0' => [
+                CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                0,
+                [
+                    CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                ],
+            ],
+            'chunk_size_2' => [
+                CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                2,
+                [
+                    CollectionStub::fromIterable([1, 2]),
+                    CollectionStub::fromIterable([3, 4]),
+                    CollectionStub::fromIterable([5]),
+                ],
+            ],
+            'chunk_size_1' => [
+                CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                1,
+                [
+                    CollectionStub::fromIterable([1]),
+                    CollectionStub::fromIterable([2]),
+                    CollectionStub::fromIterable([3]),
+                    CollectionStub::fromIterable([4]),
+                    CollectionStub::fromIterable([5]),
+                ],
+            ],
+            'chunk_size_5' => [
+                CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                5,
+                [
+                    CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                ],
+            ],
+        ];
+    }
+
     public function testDiff(): void
     {
         $collection1 = CollectionStub::fromIterable([1, 2, 3, 4, 5]);

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -488,10 +488,7 @@ final class CollectionTest extends TestCase
     #[DataProvider('chunkDataProvider')]
     public function testChunk(Collection $collection, int $chunkSize, array $expectedChunks): void
     {
-        self::assertEquals(
-            $expectedChunks,
-            $collection->chunk($chunkSize)
-        );
+        self::assertEquals($expectedChunks, $collection->chunk($chunkSize));
     }
 
     public static function chunkDataProvider(): array


### PR DESCRIPTION
# Description

The objective of this PR is to allow the user of the library to break a [`Collection`](https://github.com/kununu/collections/blob/master/src/Collection.php) into smaller chunks and optionally to operate on these chunks with an anonymous function.

e.g.

```php
$myUuids = MyUuidCollection::fromIterable([
    'a96d520d-bfb7-4a91-ac37-9f6fc3c3963a',
    '35bb7a38-abb7-4ebc-bb6a-d256cb0b1337',
    '89535491-bb46-429d-98f0-683d657b1cc8',
    '45ae5ce5-1840-4fea-a93f-342e0c9b12d1'
]);

$myUuids->eachChunk(
    2, // size
    function(Uuids $myUuidChunk) {
        $this->publisher->publish(
            $myUuidChunk
        );
    }
);
       
```