### PR TITLE
Backport chunk to v1.11

### DIFF
--- a/docs/collection-trait.md
+++ b/docs/collection-trait.md
@@ -39,7 +39,9 @@ $collection->add($item1)->add($item2);
 public function chunk(int $size): array
 ```
 
-Internally this method chunks [a copy](https://www.php.net/manual/arrayobject.getarraycopy.php) of the collection with the [`array_chunk` php function](https://www.php.net/manual/function.array-chunk.php), returning a zero indexed array of collections of the same type as the initial one.
+This method [mirrors the behavior of `array_chunk`](https://www.php.net/manual/function.array-chunk.php) and returns a zero indexed numeric array of the current collection based on the chunk size provided.
+
+Internally this method chunks the collection (by getting a copy with [getArrayCopy](https://www.php.net/manual/en/arrayiterator.getarraycopy.php) method) with the PHP [array_chunk](https://www.php.net/manual/function.array-chunk.php) function, returning a zero indexed array of collections of the same type as the initial one.
 
 ## unique
 
@@ -86,6 +88,12 @@ public function eachChunk(int $size, callable $function): self
 ```
 
 Internally, this method calls the [chunk](#chunk) method and then executes the passed anonymous function with each chunk.
+
+Callable signature:
+
+```php
+function(CollectionInterface $collection): void;
+```
 
 ## map
 

--- a/docs/collection-trait.md
+++ b/docs/collection-trait.md
@@ -32,6 +32,15 @@ A fluent version of `append`. To do stuff like:
 $collection->add($item1)->add($item2);
 ```
 
+## chunk
+
+```php
+/** @return self[] */
+public function chunk(int $size): array
+```
+
+Internally this method chunks [a copy](https://www.php.net/manual/arrayobject.getarraycopy.php) of the collection with the [`array_chunk` php function](https://www.php.net/manual/function.array-chunk.php), returning a zero indexed array of collections of the same type as the initial one.
+
 ## unique
 
 ```php
@@ -69,6 +78,14 @@ Callable signature:
 ```php
 function(mixed $element, string|float|int|bool|null $elementKey): void;
 ```
+
+## eachChunk
+
+```php
+public function eachChunk(int $size, callable $function): self
+```
+
+Internally, this method calls the [chunk](#chunk) method and then executes the passed anonymous function with each chunk.
 
 ## map
 

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -33,6 +33,21 @@ trait CollectionTrait
         return $this;
     }
 
+    /** @return self[] */
+    public function chunk(int $size): array
+    {
+        if ($size < 1) {
+            return [$this];
+        }
+
+        return array_map(
+            static function(array $chunk) {
+                return self::fromIterable($chunk);
+            },
+            array_chunk($this->getArrayCopy(), $size)
+        );
+    }
+
     public function unique(): self
     {
         return static::fromIterable(array_unique($this->toArray(), SORT_REGULAR));
@@ -70,6 +85,15 @@ trait CollectionTrait
             if ($rewind) {
                 $this->rewind();
             }
+        }
+
+        return $this;
+    }
+
+    public function eachChunk(int $size, callable $function): self
+    {
+        foreach ($this->chunk($size) as $chunk) {
+            $function($chunk);
         }
 
         return $this;

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -100,6 +100,113 @@ final class CollectionTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider chunkDataProvider
+     */
+    public function testChunk(CollectionStub $collection, int $chunkSize, array $expectedChunks): void
+    {
+        $this->assertEquals(
+            $expectedChunks,
+            $collection->chunk($chunkSize)
+        );
+    }
+
+    public static function chunkDataProvider(): array
+    {
+        return [
+            'chunk_size_0' => [
+                CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                0,
+                [
+                    CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                ],
+            ],
+            'chunk_size_2' => [
+                CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                2,
+                [
+                    CollectionStub::fromIterable([1, 2]),
+                    CollectionStub::fromIterable([3, 4]),
+                    CollectionStub::fromIterable([5]),
+                ],
+            ],
+            'chunk_size_1' => [
+                CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                1,
+                [
+                    CollectionStub::fromIterable([1]),
+                    CollectionStub::fromIterable([2]),
+                    CollectionStub::fromIterable([3]),
+                    CollectionStub::fromIterable([4]),
+                    CollectionStub::fromIterable([5]),
+                ],
+            ],
+            'chunk_size_5' => [
+                CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                5,
+                [
+                    CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider chunkEachDataProvider
+     */
+    public function testChunkEach(CollectionStub $collection, int $chunkSize, array $expectedChunks): void
+    {
+        $i = 0;
+        $collection->eachChunk(
+            $chunkSize,
+            function(CollectionStub $collection) use (&$i, $expectedChunks): void {
+                $this->assertEquals($collection, $expectedChunks[$i++]);
+            }
+        );
+    }
+
+    public static function chunkEachDataProvider(): array
+    {
+        $expectedFunction = static function(CollectionStub $stub): void {
+        };
+        return [
+            'chunk_each_size_0' => [
+                CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                0,
+                [
+                    CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                ],
+            ],
+            'chunk_each_size_2' => [
+                CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                2,
+                [
+                    CollectionStub::fromIterable([1, 2]),
+                    CollectionStub::fromIterable([3, 4]),
+                    CollectionStub::fromIterable([5]),
+                ],
+            ],
+            'chunk_each_size_1' => [
+                CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                1,
+                [
+                    CollectionStub::fromIterable([1]),
+                    CollectionStub::fromIterable([2]),
+                    CollectionStub::fromIterable([3]),
+                    CollectionStub::fromIterable([4]),
+                    CollectionStub::fromIterable([5]),
+                ],
+            ],
+            'chunk_each_size_5' => [
+                CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                5,
+                [
+                    CollectionStub::fromIterable([1, 2, 3, 4, 5]),
+                ],
+            ],
+        ];
+    }
+
     public function testEmpty(): void
     {
         $collection = new CollectionStub();

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -105,10 +105,7 @@ final class CollectionTest extends TestCase
      */
     public function testChunk(CollectionStub $collection, int $chunkSize, array $expectedChunks): void
     {
-        $this->assertEquals(
-            $expectedChunks,
-            $collection->chunk($chunkSize)
-        );
+        $this->assertEquals($expectedChunks, $collection->chunk($chunkSize));
     }
 
     public static function chunkDataProvider(): array
@@ -167,8 +164,6 @@ final class CollectionTest extends TestCase
 
     public static function chunkEachDataProvider(): array
     {
-        $expectedFunction = static function(CollectionStub $stub): void {
-        };
         return [
             'chunk_each_size_0' => [
                 CollectionStub::fromIterable([1, 2, 3, 4, 5]),


### PR DESCRIPTION
# Description

The objective of this PR is to backport the functionality of https://github.com/kununu/collections/pull/35 into 1.11.x branch so it can be used with pre PHP 8 versions.
