### PR TITLE
Add hasMultipleItems to Collections

### DIFF
--- a/docs/collection-interfaces.md
+++ b/docs/collection-interfaces.md
@@ -122,6 +122,14 @@ This method will tell you if your collection contains the given value.
  
 - `$strict` parameter allows you to use strict comparison (e.g. if your implementation uses PHP `in_array`).
 
+### hasMultipleItems
+
+```php
+public function hasMultipleItems(): bool;
+```
+
+This method will tell you if your collection has more than one element.
+ 
 ### keys
 
 ```php

--- a/docs/collection-trait.md
+++ b/docs/collection-trait.md
@@ -131,13 +131,17 @@ Internally, this method calls the [chunk](#chunk) method and then executes the p
 
 ## empty
 
-Internally is checking if the `ArrayIterator::count` returns 0
+Internally is checking if the `ArrayIterator::count` returns 0.
 
 ## has
 
 Internally, this method is calling the PHP [in_array](https://www.php.net/manual/en/function.in-array.php) to check if the element is in the array representation of the collection (obtained via `toArray` method).
 
 Please note that since it's using `in_array` it can produce unexpected results when using loose checking.
+
+### hasMultipleItems
+
+Internally is checking if the `ArrayIterator::count` returns a number greater than 1.
 
 ## keys
 

--- a/src/AbstractItemToArray.php
+++ b/src/AbstractItemToArray.php
@@ -4,26 +4,20 @@ declare(strict_types=1);
 namespace Kununu\Collection;
 
 use Kununu\Collection\Convertible\ToArray;
-use Kununu\Collection\Convertible\ToInt;
-use Kununu\Collection\Convertible\ToString;
-use Stringable;
 
 abstract class AbstractItemToArray extends AbstractItem implements ToArray
 {
+    use MapArrayItemsTrait;
+
     public function toArray(): array
     {
-        $result = [];
-        foreach ($this->getAllProperties() as $property) {
-            $element = $this->getAttribute($property);
-            $result[$property] = match (true) {
-                $element instanceof ToArray    => $element->toArray(),
-                $element instanceof ToString   => $element->toString(),
-                $element instanceof ToInt      => $element->toInt(),
-                $element instanceof Stringable => (string) $element,
-                default                        => $element,
-            };
-        }
-
-        return $result;
+        return array_combine(
+            $properties = $this->getAllProperties(),
+            $this->mapArrayItems(
+                array_map(fn(string $property): mixed => $this->getAttribute($property),
+                    $properties
+                )
+            )
+        );
     }
 }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -27,6 +27,8 @@ interface Collection extends FromIterable, ToArray
 
     public function has(mixed $value, bool $strict = true): bool;
 
+    public function hasMultipleItems(): bool;
+
     public function keys(): array;
 
     public function map(callable $function, bool $rewind = true): array;

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 namespace Kununu\Collection;
 
 use InvalidArgumentException;
-use Kununu\Collection\Convertible\ToArray;
-use Kununu\Collection\Convertible\ToInt;
-use Kununu\Collection\Convertible\ToString;
-use Stringable;
 
 trait CollectionTrait
 {
+    use MapArrayItemsTrait;
+
     public static function fromIterable(iterable $data): self|static
     {
         $result = new static();
@@ -27,7 +25,7 @@ trait CollectionTrait
         return $this->mapToArray();
     }
 
-    public function add($value): self|static
+    public function add(mixed $value): self|static
     {
         $this->append($value);
 
@@ -119,12 +117,17 @@ trait CollectionTrait
 
     public function empty(): bool
     {
-        return 0 === $this->count();
+        return $this->count() === 0;
     }
 
     public function has(mixed $value, bool $strict = true): bool
     {
         return in_array($value, $this->toArray(), $strict);
+    }
+
+    public function hasMultipleItems(): bool
+    {
+        return $this->count() > 1;
     }
 
     public function keys(): array
@@ -180,15 +183,6 @@ trait CollectionTrait
 
     protected function mapToArray(bool $withKeys = true): array
     {
-        return array_map(
-            static fn(mixed $element): mixed => match (true) {
-                $element instanceof ToArray    => $element->toArray(),
-                $element instanceof ToString   => $element->toString(),
-                $element instanceof ToInt      => $element->toInt(),
-                $element instanceof Stringable => (string) $element,
-                default                        => $element,
-            },
-            $withKeys ? $this->getArrayCopy() : $this->values()
-        );
+        return $this->mapArrayItems($withKeys ? $this->getArrayCopy() : $this->values());
     }
 }

--- a/src/MapArrayItemsTrait.php
+++ b/src/MapArrayItemsTrait.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Collection;
+
+use Kununu\Collection\Convertible\ToArray;
+use Kununu\Collection\Convertible\ToInt;
+use Kununu\Collection\Convertible\ToString;
+use Stringable;
+
+trait MapArrayItemsTrait
+{
+    protected function mapArrayItems(array $data): array
+    {
+        return array_map(
+            static fn(mixed $item): mixed => match (true) {
+                $item instanceof ToArray    => $item->toArray(),
+                $item instanceof ToString   => $item->toString(),
+                $item instanceof ToInt      => $item->toInt(),
+                $item instanceof Stringable => (string) $item,
+                default                     => $item,
+            },
+            $data
+        );
+    }
+}

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -222,15 +222,22 @@ final class CollectionTest extends TestCase
         self::assertTrue($collection->empty());
     }
 
-    public function testEmpty(): void
+    public function testEmptyAndHasMultipleItems(): void
     {
         $collection = new CollectionStub();
 
         self::assertTrue($collection->empty());
+        self::assertFalse($collection->hasMultipleItems());
 
         $collection->add(1);
 
         self::assertFalse($collection->empty());
+        self::assertFalse($collection->hasMultipleItems());
+
+        $collection->add(2);
+
+        self::assertFalse($collection->empty());
+        self::assertTrue($collection->hasMultipleItems());
     }
 
     public function testUnique(): void


### PR DESCRIPTION
# Description

The objective of this PR is to add a new method to test if a collection has multiple items (e.g. more than one item is present).

## Details

- Add `hasMultipleItems` method to `Collection` interface
- Add implementation of that method in `CollectionTrait`
- Extract the logic of mapping array values to Convertible values to `MapArrayItemsTrait`
- Add tests for the new method
- Update documentation
