### PR TITLE
Update CI workflow to use main branch instead of master

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [ opened, synchronize, reopened ]
 


### PR DESCRIPTION
# Description

The objective of this PR is to update the continuous integration workflow to use `main` branch instead of `master`
