### PR TITLE
Allow to filter a collection with an anonymous function

### DIFF
--- a/docs/collection-interfaces.md
+++ b/docs/collection-interfaces.md
@@ -206,6 +206,24 @@ public function filter(CollectionFilter $filter): self|static
 
 This will accept a `CollectionFilter` instance (with the definitions of the filter being applied to the collection), and returns a new collection with only the elements that have met the criteria defined in `$filter`.
 
+### filterWith
+
+This will filter a collection via an anonymous function. It's an easy way to filter collections without the need to define `CollectionFilter` instances, and it's more suited for simple filtering scenarios.
+
+That function should return a non-null value if the item is to be considered as a valid element or `null` if it should not be included in the result.
+
+If the value is not null it will be added to the result collection.
+
+```php
+public function filterWith(callable $function, bool $rewind = true): self|static
+```
+
+Callable signature:
+
+```php
+function(mixed $element, string|float|int|bool|null $elementKey): mixed;
+```
+
 ### groupBy
 
 ```php

--- a/docs/filterable-collection-trait.md
+++ b/docs/filterable-collection-trait.md
@@ -10,6 +10,12 @@ Internally, this method will create a new empty collection and then iterate thro
 
 If each element is an implementation of `FilterItem` and that item matches the criteria of the `CollectionFilter` (by calling the `isSatisfiedBy` method) the item will be added to the result collection.  
 
+## filterWith
+
+Internally, this method will create a new empty collection and then iterate through your collection:
+
+If the callable for each element returns a non-null value it will be added to the result collection, otherwise it will be skipped. 
+
 ## groupBy
 
 Internally, this method will create an array and initialize the groups, where each group will have as the key the value returned by the `key` of each filter passed.

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -160,7 +160,7 @@ trait CollectionTrait
     public function reduce(callable $function, mixed $initial = null, bool $rewind = true): mixed
     {
         return $this->doWithRewind(
-            function(mixed $initial) use ($function): mixed {
+            function(mixed $initial, callable $function): mixed {
                 foreach ($this as $element) {
                     $initial = $function($initial, $element, $this->key());
                 }
@@ -168,7 +168,8 @@ trait CollectionTrait
                 return $initial;
             },
             $rewind,
-            $initial
+            $initial,
+            $function
         );
     }
 

--- a/src/FilterableCollection.php
+++ b/src/FilterableCollection.php
@@ -9,5 +9,7 @@ interface FilterableCollection extends Collection
 {
     public function filter(CollectionFilter $filter): self|static;
 
+    public function filterWith(callable $function, bool $rewind = true): self|static;
+
     public function groupBy(bool $removeEmptyGroups, CollectionFilter ...$filters): array;
 }

--- a/tests/FilterableCollectionTest.php
+++ b/tests/FilterableCollectionTest.php
@@ -54,6 +54,35 @@ final class FilterableCollectionTest extends TestCase
         self::assertEmpty($collection->filter($filter));
     }
 
+    public function testFilterWith(): void
+    {
+        $collection = (new FilterableCollectionStub())
+            ->add(new FilterItemStub('a'))
+            ->add(new FilterItemStub('aa'))
+            ->add(new FilterItemStub('aa'))
+            ->add(new FilterItemStub('b'))
+            ->add(new FilterItemStub('c'));
+
+        $filter1 = static fn(FilterItemStub $stub): ?FilterItemStub => str_starts_with($stub->itemKey, 'a')
+            ? $stub
+            : null;
+
+        $filter2 = static fn(FilterItemStub $stub): ?FilterItemStub => str_starts_with($stub->itemKey, 'z')
+            ? $stub
+            : null;
+
+        self::assertEquals(
+            new FilterableCollectionStub(
+                new FilterItemStub('a'),
+                new FilterItemStub('aa'),
+                new FilterItemStub('aa')
+            ),
+            $collection->filterWith($filter1)
+        );
+
+        self::assertEmpty($collection->filterWith($filter2));
+    }
+
     public function testGroupBy(): void
     {
         $filter1 = new class extends BaseFilter {

--- a/tests/Stub/FilterItemStub.php
+++ b/tests/Stub/FilterItemStub.php
@@ -7,7 +7,7 @@ use Kununu\Collection\Filter\FilterItem;
 
 final readonly class FilterItemStub implements FilterItem
 {
-    public function __construct(private string $itemKey, private ?string $extra = null)
+    public function __construct(public string $itemKey, private ?string $extra = null)
     {
     }
 

--- a/tests/Stub/FilterableCollectionStub.php
+++ b/tests/Stub/FilterableCollectionStub.php
@@ -21,4 +21,12 @@ use Kununu\Collection\Filter\CollectionFilter;
  */
 final class FilterableCollectionStub extends AbstractFilterableCollection
 {
+    public function __construct(FilterItemStub ...$filterItemStubs)
+    {
+        parent::__construct();
+
+        foreach ($filterItemStubs as $filterItemStub) {
+            $this->append($filterItemStub);
+        }
+    }
 }


### PR DESCRIPTION
# Description

The objective of this PR is to allow to filter a collection with an anonymous function

## Details

### New Features
Allow to filter a collection with an anonymous function

### Other changes
- Add `filterWith` to `FilterableCollection` interface
- Implement it in `FilterableCollectionTrait`
- Add tests for new method
- Update documentation
