### PR TITLE
Version 8.0

### DIFF
--- a/.github/workflows/auto_assign_owner.yml
+++ b/.github/workflows/auto_assign_owner.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto assign owner
-        uses: toshimaru/auto-author-assign@v3.0.2
+        uses: toshimaru/auto-author-assign@v3.0.3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -68,6 +68,7 @@ jobs:
       matrix:
         php-version:
           - 8.4
+          - 8.5
         dependencies:
           - lowest
           - highest
@@ -83,6 +84,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           extensions: mbstring
+          ini-values: "zend.assertions=1"
           coverage: pcov
 
       - name: Install Composer Dependencies
@@ -128,7 +130,7 @@ jobs:
           sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' tests-junit.xml
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v8.0.0
+        uses: SonarSource/sonarqube-scan-action@v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,357 @@
+# Changelog
+
+All notable changes to `kununu/collections` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Entries before this file existed were reconstructed from the [git tags](https://github.com/kununu/collections/tags) and PR history, so older releases are summarized rather than exhaustive.
+
+## [Unreleased]
+
+_No unreleased changes yet._
+
+## [8.0.0] - 2026-06-22
+
+Major release. See **Backwards compatibility** below before upgrading.
+
+### Added
+
+- `Collection::intersect(self $other): self|static`
+  - Returns a new collection with the intersection between two collections of the same type (throws `NotSameCollectionTypeException` if the other collection is not the same type).
+- `Collection::merge(self ...$others): self|static`
+  - Returns a new collection with the items of this collection followed by the items of the given ones.
+  - Items are added through the collection's own `append`, so any overridden append logic (validation, transformation, keying) is honored.
+  - Same-type guard as `diff`/`intersect`.
+- `Collection::collectionOrNull(): self|static|null`
+  - Returns `null` when the collection is empty, otherwise the collection itself.
+- `Exception\NotSameCollectionTypeException`
+  - Thrown by `diff`, `intersect`, and `merge` when the other collection is not the same type
+  - Extends `InvalidArgumentException`, so existing `catch (InvalidArgumentException)` handlers keep working.
+- `AbstractBasicItem::getAllProperties` is now cached per class, instead of being recomputed on each `new` call.
+- `KeyValueInterface` - a shared interface for key-value containers, implemented by both `KeyValue` and `EnumKeyValue\AbstractEnumKeyValue`.
+- `KeyValueTrait` - extracts the shared storage, iteration, and `ArrayAccess` behavior of the key-value containers so it can be reused by custom implementations.
+- `EnumKeyValue\AbstractEnumKeyValue` now supports `ArrayAccess` (e.g. `$item['key']`), inherited from the shared `KeyValueTrait`.
+
+### Changed
+
+- `@phpstan-require-extends ArrayIterator` was added to `CollectionTrait` and `FilterableCollectionTrait` to document (and let static analysis surface) the existing requirement that these traits can only be used by classes extending `ArrayIterator`.
+- `KeyValue` and `EnumKeyValue\AbstractEnumKeyValue` now implement the new `KeyValueInterface` (previously each declared the underlying `ArrayAccess`/`Countable`/`IteratorAggregate`/`FromArray`/`FromIterable`/`ToArray` interfaces individually). All existing `instanceof` checks against those interfaces continue to hold.
+- Documentation updated for the new methods.
+
+### Backwards compatibility
+
+- **Extending `AbstractCollection`/`AbstractFilterableCollection`** the upgrade is drop-in
+  - The new methods (`intersect`, `merge`, `collectionOrNull`) are inherited automatically
+  - No action needed unless your subclass already declares a method with one of those names
+    - **Incompatible signature** ⇒ fatal `Declaration ... must be compatible with ...` error at class load.
+      - Rename your method or align its signature with the interface.
+    - **Compatible signature** ⇒ no error, but your implementation silently overrides the library's.
+      - Verify that is intended (and that nothing relied on the new built-in behavior).
+- **Direct implementers of `Collection`** (not extending the abstract classes/not using `CollectionTrait`) must add the three new methods to satisfy the interface.
+- **Exception type:**
+  - `diff`, `intersect`, and `merge` now throw `Exception\NotSameCollectionTypeException` instead of a plain `InvalidArgumentException` when the other collection is not the same type
+  - It extends `InvalidArgumentException`, so `catch (InvalidArgumentException)` keeps working
+    - Update any assertions or checks that compare the exact exception class.
+- **`AbstractEnumKeyValue` now also implements `ArrayAccess`.** This is additive — no action needed. (Only relevant if a subclass already declared its own `offset*` methods, which would now override the inherited ones.)
+
+### Other
+
+- Introduce `CHANGELOG.md`
+- Update CI components and dev dependencies
+- Added a `suggest` entry for `phpunit/phpunit` (only needed by consumers extending `AbstractCollectionTestCase`).
+- `composer test`/`composer test-coverage` now run with `zend.assertions=1`, matching CI.
+
+## [7.0.0] - 2026-02-12
+
+### Added
+
+- `Convertible\FromStringable` interface — create an item from a `string` or `Stringable`. (#60)
+
+### Changed
+
+- Reworked `FilterableCollectionTrait` and expanded the filtering/grouping internals (`CollectionFilters`, `CompositeFilter`, `FilterItemTrait`).
+
+### Backwards compatibility
+- **BREAKING:** Raised the minimum supported PHP version to `>=8.4`
+
+## [6.6.0] - 2026-01-07
+
+### Added
+
+- `EnumKeyTrait`. (#58)
+
+## [6.5.0] - 2025-12-18
+
+### Added
+
+- `EnumKeyValue\AbstractEnumKeyValue`.
+
+### Changed
+
+- Replaced `kununu/scripts` with `kununu/code-tools`.
+
+## [6.4.0] - 2025-08-12
+
+### Added
+
+- `FilterableCollection::filterWith()`
+  - filter a collection with an anonymous function.
+
+## [6.3.0] - 2025-08-05
+
+### Added
+
+- `AbstractCollectionTestCase` to help test collections downstream.
+
+## [6.2.0] - 2025-07-03
+
+### Added
+
+- `Collection::hasMultipleItems()`.
+
+## [6.1.0] - 2025-06-16
+
+### Added
+
+- `KeyValue`.
+
+## [6.0.0] - 2025-04-23
+
+### Backwards compatibility
+
+- **BREAKING:** Raised the minimum supported PHP version to `>=8.3`.
+
+## [5.5.0] - 2025-07-03
+
+### Added
+
+- Backport of `Collection::hasMultipleItems()` to the 5.x line.
+
+## [5.4.0] - 2025-06-16
+
+### Added
+
+- Backport of `KeyValue` to the 5.x line.
+
+## [5.3.0] - 2025-04-23
+
+### Changed
+
+- Backport from the 6.0 line to 5.x.
+
+## [5.2.1] - 2025-03-31
+
+### Fixed
+
+- JMS serializer config filename.
+
+## [5.2.0] - 2025-03-28
+
+### Added
+
+- New builders for `AbstractItem`.
+
+## [5.1.0] - 2024-11-18
+
+### Added
+
+- `Collection::chunk()` and `Collection::eachChunk()`.
+
+## [5.0.0] - 2024-07-15
+
+### Added
+
+- **BREAKING:** Introduced the collection interfaces (`Collection`, `FilterableCollection`).
+
+## [4.1.0] - 2024-06-19
+
+### Changed
+
+- Split the non-builder code of `AbstractItem` into `AbstractBasicItem`.
+
+## [4.0.0] - 2024-03-13
+
+### Changed
+
+- **BREAKING:** Dropped PHP 8.0 support; minimum version is now PHP 8.1.
+
+## [3.1.1] - 2024-01-05
+
+### Changed
+
+- Updated continuous integration components.
+
+## [3.1.0] - 2023-10-11
+
+### Changed
+
+- Improved `AbstractItem` default builders.
+
+## [3.0.2] - 2023-06-20
+
+### Changed
+
+- `Convertible\From*` interfaces now also return `static`.
+
+## [3.0.1] - 2023-03-14
+
+### Fixed
+
+- Addressed Sonar issues.
+
+## [3.0.0] - 2023-03-14
+
+### Changed
+
+- Open sourced the library.
+
+## [2.0.0] - 2023-03-14
+
+### Changed
+
+- **BREAKING:** Dropped support for PHP 7.x.
+
+## [1.11.1] - 2024-11-18
+
+### Added
+
+- Backport of `chunk` / `eachChunk` to the 1.11.x line.
+
+## [1.11.0] - 2022-12-19
+
+### Added
+
+- `Mapper`.
+
+## [1.10.0] - 2022-08-26
+
+### Added
+
+- Additional build getters for `AbstractItem`.
+
+## [1.9.0] - 2022-02-23
+
+### Added
+
+- `AutoSortableOffsetSetTrait`.
+
+## [1.8.0] - 2022-01-19
+
+### Fixed
+
+- `AbstractItemToArray::toArray`.
+
+## [1.7.0] - 2021-12-13
+
+### Added
+
+- `AbstractItemToArray`.
+
+## [1.6.3] - 2021-10-06
+
+### Changed
+
+- Allow installation on PHP 8.
+
+## [1.6.2] - 2021-08-26
+
+### Changed
+
+- Always use the latest version of `kununu/scripts`.
+
+## [1.6.1] - 2021-05-11
+
+### Changed
+
+- Updated `kununu/scripts` to `^2.0`.
+
+## [1.6.0] - 2021-03-23
+
+### Added
+
+- `Collection::map()` and `Collection::reduce()`.
+
+## [1.5.0] - 2021-03-16
+
+### Added
+
+- Getter builders in `AbstractItem` for `string` / `bool` / `int` types.
+
+## [1.4.0] - 2021-02-18
+
+### Added
+
+- `Collection::each()` to iterate through each item of the collection.
+
+## [1.3.0] - 2021-02-05
+
+### Added
+
+- `AbstractItem`.
+
+## [1.2.0] - 2021-02-01
+
+### Changed
+
+- Reworked the approach to the abstract collections (regular and filterable).
+
+## [1.1.1] - 2021-02-01
+
+### Fixed
+
+- `CollectionTrait::fromIterable` so it can be used by `AbstractCollection` and `AbstractFilterableCollection`.
+
+## [1.1.0] - 2021-01-29
+
+### Added
+
+- Abstract base collections (regular and filterable).
+
+## [1.0.0] - 2020-08-17
+
+### Added
+
+- Initial release: `CollectionTrait` and `FilterableCollectionTrait`.
+
+[unreleased]: https://github.com/kununu/collections/compare/v8.0.0...HEAD
+[8.0.0]: https://github.com/kununu/collections/compare/v7.0.0...v8.0.0
+[7.0.0]: https://github.com/kununu/collections/compare/v6.6.0...v7.0.0
+[6.6.0]: https://github.com/kununu/collections/compare/v6.5.0...v6.6.0
+[6.5.0]: https://github.com/kununu/collections/compare/v6.4.0...v6.5.0
+[6.4.0]: https://github.com/kununu/collections/compare/v6.3.0...v6.4.0
+[6.3.0]: https://github.com/kununu/collections/compare/v6.2.0...v6.3.0
+[6.2.0]: https://github.com/kununu/collections/compare/v6.1.0...v6.2.0
+[6.1.0]: https://github.com/kununu/collections/compare/v6.0.0...v6.1.0
+[6.0.0]: https://github.com/kununu/collections/compare/v5.2.1...v6.0.0
+[5.5.0]: https://github.com/kununu/collections/compare/v5.4.0...v5.5.0
+[5.4.0]: https://github.com/kununu/collections/compare/v5.3.0...v5.4.0
+[5.3.0]: https://github.com/kununu/collections/compare/v5.2.1...v5.3.0
+[5.2.1]: https://github.com/kununu/collections/compare/v5.2.0...v5.2.1
+[5.2.0]: https://github.com/kununu/collections/compare/v5.1.0...v5.2.0
+[5.1.0]: https://github.com/kununu/collections/compare/v5.0.0...v5.1.0
+[5.0.0]: https://github.com/kununu/collections/compare/v4.1.0...v5.0.0
+[4.1.0]: https://github.com/kununu/collections/compare/v4.0.0...v4.1.0
+[4.0.0]: https://github.com/kununu/collections/compare/v3.1.1...v4.0.0
+[3.1.1]: https://github.com/kununu/collections/compare/v3.1.0...v3.1.1
+[3.1.0]: https://github.com/kununu/collections/compare/v3.0.2...v3.1.0
+[3.0.2]: https://github.com/kununu/collections/compare/v3.0.1...v3.0.2
+[3.0.1]: https://github.com/kununu/collections/compare/v3.0.0...v3.0.1
+[3.0.0]: https://github.com/kununu/collections/compare/v2.0.0...v3.0.0
+[2.0.0]: https://github.com/kununu/collections/compare/v1.11.0...v2.0.0
+[1.11.1]: https://github.com/kununu/collections/compare/v1.11.0...v1.11.1
+[1.11.0]: https://github.com/kununu/collections/compare/v1.10.0...v1.11.0
+[1.10.0]: https://github.com/kununu/collections/compare/v1.9.0...v1.10.0
+[1.9.0]: https://github.com/kununu/collections/compare/v1.8.0...v1.9.0
+[1.8.0]: https://github.com/kununu/collections/compare/v1.7.0...v1.8.0
+[1.7.0]: https://github.com/kununu/collections/compare/v1.6.3...v1.7.0
+[1.6.3]: https://github.com/kununu/collections/compare/v1.6.2...v1.6.3
+[1.6.2]: https://github.com/kununu/collections/compare/v1.6.1...v1.6.2
+[1.6.1]: https://github.com/kununu/collections/compare/v1.6.0...v1.6.1
+[1.6.0]: https://github.com/kununu/collections/compare/v1.5.0...v1.6.0
+[1.5.0]: https://github.com/kununu/collections/compare/v1.4.0...v1.5.0
+[1.4.0]: https://github.com/kununu/collections/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/kununu/collections/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/kununu/collections/compare/v1.1.1...v1.2.0
+[1.1.1]: https://github.com/kununu/collections/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/kununu/collections/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/kununu/collections/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ More details:
 - [Mapper](docs/mapper.md)
 - [Collections Test Case](docs/abstract-collection-test-case.md)
 
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for the list of notable changes in each release.
+
 ## Contribute
 
 If you are interested in contributing read our [contributing guidelines](/CONTRIBUTING.md).

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,15 @@
     "ext-mbstring": "*"
   },
   "require-dev": {
-    "kununu/code-tools": "^4.0",
-    "phpstan/phpstan": "^2.1",
+    "kununu/code-tools": "^4.1",
+    "phpstan/phpstan": "^2.2",
     "phpstan/phpstan-phpunit": "^2.0",
     "phpunit/phpunit": "^13.1",
     "rector/rector": "^2.4",
     "shipmonk/composer-dependency-analyser": "^1.8"
+  },
+  "suggest": {
+    "phpunit/phpunit": "Required only if you extend AbstractCollectionTestCase in your own test suite"
   },
   "minimum-stability": "stable",
   "autoload": {
@@ -48,8 +51,11 @@
     "rector-fix": "rector process --config rector-ci.php src/ tests/",
     "sniffer": "phpcs",
     "sniffer-fix": "phpcbf",
-    "test": "phpunit --testsuite Full --testdox --testdox-summary --no-coverage --no-logging",
-    "test-coverage": "XDEBUG_MODE=coverage phpunit --testsuite Full --testdox --testdox-summary --log-junit tests/.results/tests-junit.xml --coverage-clover tests/.results/tests-clover.xml --coverage-html tests/.results/html/"
+    "test": "@php -d zend.assertions=1 vendor/bin/phpunit --testsuite Full --testdox --testdox-summary --no-coverage --no-logging",
+    "test-coverage": [
+      "@putenv XDEBUG_MODE=coverage",
+      "@php -d zend.assertions=1 vendor/bin/phpunit --testsuite Full --testdox --testdox-summary --log-junit tests/.results/tests-junit.xml --coverage-clover tests/.results/tests-clover.xml --coverage-html tests/.results/html/"
+    ]
   },
   "scripts-descriptions": {
     "cs": "Run PHP CS Fixer with kununu code standards",

--- a/docs/abstract-collections.md
+++ b/docs/abstract-collections.md
@@ -11,15 +11,18 @@ declare(strict_types=1);
 use Kununu\Collection\AbstractCollection;
 
 /**
- * @method static self fromIterable(iterable $data)
- * @method        self add(mixed $value)
- * @method        self clear()
- * @method        int  count()
- * @method        self diff(Collection $other)
- * @method        self duplicates(bool $strict = true, bool $uniques = false)
- * @method        self each(callable $function, bool $rewind = true)
- * @method        self reverse()
- * @method        self unique()
+ * @method static self      fromIterable(iterable $data)
+ * @method        self      add(mixed $value)
+ * @method        self      clear()
+ * @method        self|null collectionOrNull()
+ * @method        int       count()
+ * @method        self      diff(Collection $other)
+ * @method        self      duplicates(bool $strict = true, bool $uniques = false)
+ * @method        self      each(callable $function, bool $rewind = true)
+ * @method        self      intersect(Collection $other)
+ * @method        self      merge(Collection ...$others)
+ * @method        self      reverse()
+ * @method        self      unique()
  */
 final class MyCollection extends AbstractCollection 
 {
@@ -41,16 +44,20 @@ declare(strict_types=1);
 use Kununu\Collection\AbstractFilterableCollection;
 
 /**
- * @method static self fromIterable(iterable $data)
- * @method        self add(mixed $value)
- * @method        self clear()
- * @method        int  count()
- * @method        self diff(Collection $other)
- * @method        self duplicates(bool $strict = true, bool $uniques = false)
- * @method        self each(callable $function, bool $rewind = true)
- * @method        self reverse()
- * @method        self unique()
- * @method        self filter(CollectionFilter $filter)
+ * @method static self      fromIterable(iterable $data)
+ * @method        self      add(mixed $value)
+ * @method        self      clear()
+ * @method        self|null collectionOrNull()
+ * @method        int       count()
+ * @method        self      diff(Collection $other)
+ * @method        self      duplicates(bool $strict = true, bool $uniques = false)
+ * @method        self      each(callable $function, bool $rewind = true)
+ * @method        self      filter(CollectionFilter $filter)
+ * @method        self      filterWith(callable $function, bool $rewind = true)
+ * @method        self      intersect(Collection $other)
+ * @method        self      merge(Collection ...$others)
+ * @method        self      reverse()
+ * @method        self      unique()
  */
 final class MyCollection extends AbstractFilterableCollection
 {

--- a/docs/collection-interfaces.md
+++ b/docs/collection-interfaces.md
@@ -47,15 +47,23 @@ $collection->add($item1)->add($item2);
 ### chunk
 
 ```php
-/** @return self[]|static[] */
+/** @return array<self|static> */
 public function chunk(int $size): array
 ```
 
-This method [mirrors the behavior of `array_chunk`](https://www.php.net/manual/function.array-chunk.php) and returns a zero indexed numeric array of the current collection based on the chunk size provided.
+This method mirrors the behavior of [`array_chunk`](https://www.php.net/manual/function.array-chunk.php) and returns a zero indexed numeric array of the current collection based on the chunk size provided.
 
 ### clear
 
 This method should remove all the items of the collection and since is fluent it should return the collection. 
+
+### collectionOrNull
+
+```php
+public function collectionOrNull(): self|static|null;
+```
+
+This method should return `null` when the collection is empty, otherwise the collection itself.
 
 ### count
 
@@ -68,6 +76,22 @@ public function diff(self $other): self|static;
 ```
 
 This method will produce a collection with the difference between your collection and another instance.
+
+### intersect
+
+```php
+public function intersect(self $other): self|static;
+```
+
+This method will produce a collection with the intersection between your collection and another instance.
+
+### merge
+
+```php
+public function merge(self ...$others): self|static;
+```
+
+This method will produce a new collection containing the items of your collection followed by the items of the given instances.
 
 ### duplicates
 

--- a/docs/collection-trait.md
+++ b/docs/collection-trait.md
@@ -1,6 +1,6 @@
 # CollectionTrait
 
-This is the most basic trait, and it provides an implementation of the `Collection` interface.
+This is the most basic trait, and it provides an implementation of the `Collection` interface. It can be used directly on a class that is extending `ArrayIterator` (or a child of it, like `AbstractCollection`).
 
 Some details about the implementation:
 
@@ -95,25 +95,49 @@ $collection->toArray();
 
 Internally it is calling the `ArrayIterator::append` and returning the instance to allow fluent calls.
 
+## chunk
+
+Internally this method chunks the collection (by getting a copy with [getArrayCopy](https://www.php.net/manual/en/arrayiterator.getarraycopy.php) method) with the PHP [array_chunk](https://www.php.net/manual/function.array-chunk.php) function, returning a zero indexed array of collections of the same type as the initial one.
+
 ## clear
 
-Internally it is calling the `keys` method and for each key it is call the `ArrayIterator::offsetUnset`  and returning the instance to allow fluent calls.
+Internally it is calling the `keys` method and for each key it is call the `ArrayIterator::offsetUnset` and returning the instance to allow fluent calls.
+
+## collectionOrNull
+
+Returns `null` when the collection is empty (relying on the `empty()` method), otherwise returns the collection itself.
+
+This is handy when an empty collection should be treated as "no value", for example when returning from a repository or service method whose contract is to return either a collection or `null`.
 
 ## count
 
 Internally it is calling the `ArrayIterator::count` method.
 
-## chunk
-
-Internally this method chunks the collection (by getting a copy with [getArrayCopy](https://www.php.net/manual/en/arrayiterator.getarraycopy.php) method) with the PHP [array_chunk](https://www.php.net/manual/function.array-chunk.php) function, returning a zero indexed array of collections of the same type as the initial one.
-
 ## diff
 
-To check the difference between two collections first it checks that the other collection is of the same type as the current one.
+To check the difference between two collections first it checks that the other collection is of the same type as the current one (otherwise a `NotSameCollectionTypeException` is thrown).
 
 Then it is calling the PHP [array_diff](https://www.php.net/manual/en/function.array-diff.php) between the [serialize](https://www.php.net/manual/en/https://www.php.net/manual/en/function.serialize.php) representation of each collection represented as an array (by calling the `toArray` method on each collection).
 
 Finally, it is creating a new instance of the collection by using [unserialize](https://www.php.net/manual/en/function.unserialize) on each member of the diff.
+
+## intersect
+
+To check the intersection between two collections first it checks that the other collection is of the same type as the current one (otherwise a `NotSameCollectionTypeException` is thrown).
+
+Then it is calling the PHP [array_intersect](https://www.php.net/manual/en/function.array-intersect.php) between the [serialize](https://www.php.net/manual/en/https://www.php.net/manual/en/function.serialize.php) representation of each collection represented as an array (by calling the `toArray` method on each collection).
+
+Finally, it is creating a new instance of the collection by using [unserialize](https://www.php.net/manual/en/function.unserialize) on each member of the intersection.
+
+## merge
+
+Merges the current collection with one or more other collections (it is variadic) into a brand-new collection, leaving the source collections untouched.
+
+First it checks that every given collection is of the same type as the current one (otherwise a `NotSameCollectionTypeException` is thrown).
+
+Then it creates a new instance of the collection and iterates the current collection and each of the given ones (with the `each` method), appending every element to the result via its `append` method.
+
+Because it relies on `append`, any custom logic your collection defines there (validation, transformation, keying, deduplication, ...) is applied to the merged elements as well.
 
 ## duplicates
 
@@ -143,7 +167,7 @@ Internally, this method is calling the PHP [in_array](https://www.php.net/manual
 
 Please note that since it's using `in_array` it can produce unexpected results when using loose checking.
 
-### hasMultipleItems
+## hasMultipleItems
 
 Internally is checking if the `ArrayIterator::count` returns a number greater than 1.
 

--- a/src/AbstractBasicItem.php
+++ b/src/AbstractBasicItem.php
@@ -18,6 +18,9 @@ abstract class AbstractBasicItem
 
     private const FormatOption FORMAT_OPTION = FormatOption::LowerCaseFirst;
 
+    /** @var array<class-string, list<string>> */
+    private static array $propertiesCache = [];
+
     private array $attributes = [];
 
     public function __construct(array $attributes = [])
@@ -74,8 +77,14 @@ abstract class AbstractBasicItem
 
     protected function getAllProperties(): array
     {
+        return self::$propertiesCache[static::class] ??= self::resolveAllProperties();
+    }
+
+    /** @return list<string> */
+    private static function resolveAllProperties(): array
+    {
         $properties = static::PROPERTIES;
-        foreach (class_parents($this) as $parentClass) {
+        foreach (class_parents(static::class) as $parentClass) {
             $properties = array_merge($properties, $parentClass::PROPERTIES);
         }
 

--- a/src/AbstractCollection.php
+++ b/src/AbstractCollection.php
@@ -6,15 +6,18 @@ namespace Kununu\Collection;
 use ArrayIterator;
 
 /**
- * @method static self fromIterable(iterable $data)
- * @method        self add(mixed $value)
- * @method        self clear()
- * @method        int  count()
- * @method        self diff(Collection $other)
- * @method        self duplicates(bool $strict = true, bool $uniques = false)
- * @method        self each(callable $function, bool $rewind = true)
- * @method        self reverse()
- * @method        self unique()
+ * @method static self      fromIterable(iterable $data)
+ * @method        self      add(mixed $value)
+ * @method        self      clear()
+ * @method        self|null collectionOrNull()
+ * @method        int       count()
+ * @method        self      diff(Collection $other)
+ * @method        self      duplicates(bool $strict = true, bool $uniques = false)
+ * @method        self      each(callable $function, bool $rewind = true)
+ * @method        self      intersect(Collection $other)
+ * @method        self      merge(Collection ...$others)
+ * @method        self      reverse()
+ * @method        self      unique()
  */
 abstract class AbstractCollection extends ArrayIterator implements Collection
 {

--- a/src/AbstractFilterableCollection.php
+++ b/src/AbstractFilterableCollection.php
@@ -7,16 +7,20 @@ use ArrayIterator;
 use Kununu\Collection\Filter\CollectionFilter;
 
 /**
- * @method static self fromIterable(iterable $data)
- * @method        self add(mixed $value)
- * @method        self clear()
- * @method        int  count()
- * @method        self diff(Collection $other)
- * @method        self duplicates(bool $strict = true, bool $uniques = false)
- * @method        self each(callable $function, bool $rewind = true)
- * @method        self reverse()
- * @method        self unique()
- * @method        self filter(CollectionFilter $filter)
+ * @method static self      fromIterable(iterable $data)
+ * @method        self      add(mixed $value)
+ * @method        self      clear()
+ * @method        self|null collectionOrNull()
+ * @method        int       count()
+ * @method        self      diff(Collection $other)
+ * @method        self      duplicates(bool $strict = true, bool $uniques = false)
+ * @method        self      each(callable $function, bool $rewind = true)
+ * @method        self      filter(CollectionFilter $filter)
+ * @method        self      filterWith(callable $function, bool $rewind = true)
+ * @method        self      intersect(Collection $other)
+ * @method        self      merge(Collection ...$others)
+ * @method        self      reverse()
+ * @method        self      unique()
  */
 abstract class AbstractFilterableCollection extends ArrayIterator implements FilterableCollection
 {

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -11,12 +11,18 @@ interface Collection extends FromIterable, ToArray, Countable
 {
     public function add(mixed $value): self|static;
 
-    /** @return self[]|static[] */
+    /** @return array<self|static> */
     public function chunk(int $size): array;
 
     public function clear(): self|static;
 
+    public function collectionOrNull(): self|static|null;
+
     public function diff(self $other): self|static;
+
+    public function intersect(self $other): self|static;
+
+    public function merge(self ...$others): self|static;
 
     public function duplicates(bool $strict = true, bool $uniques = false): self|static;
 

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -3,8 +3,10 @@ declare(strict_types=1);
 
 namespace Kununu\Collection;
 
-use InvalidArgumentException;
+use ArrayIterator;
+use Kununu\Collection\Exception\NotSameCollectionTypeException;
 
+/** @phpstan-require-extends ArrayIterator */
 trait CollectionTrait
 {
     use MapArrayItemsTrait;
@@ -33,7 +35,7 @@ trait CollectionTrait
         return $this;
     }
 
-    /** @return self[] */
+    /** @return array<self|static> */
     public function chunk(int $size): array
     {
         if ($size < 1) {
@@ -57,10 +59,15 @@ trait CollectionTrait
         return $this;
     }
 
+    public function collectionOrNull(): self|static|null
+    {
+        return $this->empty() ? null : $this;
+    }
+
     public function diff(Collection $other): self|static
     {
         if (!$other instanceof static) {
-            throw new InvalidArgumentException('Other collection must be of the same type');
+            throw new NotSameCollectionTypeException();
         }
 
         return static::fromIterable(
@@ -76,14 +83,49 @@ trait CollectionTrait
         );
     }
 
+    public function intersect(Collection $other): self|static
+    {
+        if (!$other instanceof static) {
+            throw new NotSameCollectionTypeException();
+        }
+
+        return static::fromIterable(
+            array_values(
+                array_map(
+                    unserialize(...),
+                    array_intersect(
+                        array_map(serialize(...), $this->toArray()),
+                        array_map(serialize(...), $other->toArray())
+                    )
+                )
+            )
+        );
+    }
+
+    public function merge(Collection ...$others): self|static
+    {
+        // @phpstan-ignore new.static
+        $result = new static();
+
+        foreach ([$this, ...$others] as $collection) {
+            if (!$collection instanceof static) {
+                throw new NotSameCollectionTypeException();
+            }
+
+            $collection->each(static fn(mixed $element) => $result->append($element));
+        }
+
+        return $result;
+    }
+
     public function duplicates(bool $strict = true, bool $uniques = false): self|static
     {
         return $this->doWithRewind(
             function(Collection $elements, Collection $duplicates, bool $strict, bool $uniques): Collection {
                 foreach ($this as $element) {
                     match ($elements->has($element, $strict)) {
-                        true  => $duplicates->add($element),
                         false => $elements->add($element),
+                        true  => $duplicates->add($element),
                     };
                 }
 

--- a/src/EnumKeyValue/AbstractEnumKeyValue.php
+++ b/src/EnumKeyValue/AbstractEnumKeyValue.php
@@ -3,20 +3,17 @@ declare(strict_types=1);
 
 namespace Kununu\Collection\EnumKeyValue;
 
-use ArrayIterator;
 use BadMethodCallException;
-use Countable;
-use IteratorAggregate;
-use Kununu\Collection\Convertible\FromArray;
-use Kununu\Collection\Convertible\FromIterable;
-use Kununu\Collection\Convertible\ToArray;
 use Kununu\Collection\EnumKeyValue\Exception\RemovingRequiredKeyException;
 use Kununu\Collection\EnumKeyValue\Exception\RequiredKeyMissingException;
 use Kununu\Collection\Helper\FormatOption;
 use Kununu\Collection\Helper\MethodsHelperTrait;
+use Kununu\Collection\KeyValueInterface;
+use Kununu\Collection\KeyValueTrait;
 
-abstract class AbstractEnumKeyValue implements Countable, IteratorAggregate, FromArray, FromIterable, ToArray
+abstract class AbstractEnumKeyValue implements KeyValueInterface
 {
+    use KeyValueTrait;
     use MethodsHelperTrait;
 
     protected const string HAS_PREFIX = 'has';
@@ -24,27 +21,6 @@ abstract class AbstractEnumKeyValue implements Countable, IteratorAggregate, Fro
     protected const string GETTER_PREFIX = 'get';
     protected const string REMOVE_PREFIX = 'remove';
     protected const FormatOption FORMAT_OPTION = FormatOption::UpperCaseFirst;
-
-    private array $values = [];
-
-    /** @param array<string, mixed> $data */
-    public static function fromArray(array $data): self|static
-    {
-        return self::fromIterable($data);
-    }
-
-    /** @param iterable<string, mixed> $data */
-    public static function fromIterable(iterable $data): self|static
-    {
-        // @phpstan-ignore new.static
-        $instance = new static();
-
-        foreach ($data as $key => $value) {
-            $instance->set($key, $value);
-        }
-
-        return $instance;
-    }
 
     public function __call(string $method, array $args)
     {
@@ -66,11 +42,6 @@ abstract class AbstractEnumKeyValue implements Countable, IteratorAggregate, Fro
         };
     }
 
-    public function count(): int
-    {
-        return count($this->values);
-    }
-
     /** @throws RequiredKeyMissingException */
     public function get(string|EnumKeyInterface $key, mixed $default = null): mixed
     {
@@ -81,12 +52,6 @@ abstract class AbstractEnumKeyValue implements Countable, IteratorAggregate, Fro
         }
 
         return $this->has($key) ? $this->values[$key->key()] : $default;
-    }
-
-    /** @return ArrayIterator<string, mixed> */
-    public function getIterator(): ArrayIterator
-    {
-        return new ArrayIterator($this->values);
     }
 
     public function has(string|EnumKeyInterface $key): bool
@@ -121,16 +86,6 @@ abstract class AbstractEnumKeyValue implements Countable, IteratorAggregate, Fro
         $this->values[self::createKey($key)->key()] = $value;
 
         return $this;
-    }
-
-    public function toArray(): array
-    {
-        return $this->values;
-    }
-
-    public function values(): array
-    {
-        return array_values($this->values);
     }
 
     abstract protected static function createKeyFromString(string $key): EnumKeyInterface;

--- a/src/Exception/NotSameCollectionTypeException.php
+++ b/src/Exception/NotSameCollectionTypeException.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Collection\Exception;
+
+use InvalidArgumentException;
+
+final class NotSameCollectionTypeException extends InvalidArgumentException
+{
+    public function __construct()
+    {
+        parent::__construct('Other collection must be of the same type', 400);
+    }
+}

--- a/src/Filter/CollectionFilters.php
+++ b/src/Filter/CollectionFilters.php
@@ -24,8 +24,6 @@ final class CollectionFilters extends AbstractCollection
 
     private const string INVALID = 'Can only append %s or another instance of %s';
 
-    private ?array $groups = null;
-
     public function __construct(CollectionFilter ...$filters)
     {
         if (count($filters)) {
@@ -55,32 +53,25 @@ final class CollectionFilters extends AbstractCollection
 
     public function getGroupsForCollection(Collection $collection, bool $removeEmptyGroups): array
     {
-        $this->groups = $this->reduce(
-            static function(array $group, CollectionFilter $filter): array {
-                $group[$filter->key()] = [];
+        $groups = array_merge(...$this->map(static fn(CollectionFilter $filter): array => [$filter->key() => []]));
 
-                return $group;
-            },
-            []
-        );
+        $collection->each(function(mixed $item) use (&$groups): void {
+            $groups = $this->updateGroupsForItem($item, $groups);
+        });
 
-        $collection->each(fn(mixed $item) => $this->updateGroupsForItem($item));
-
-        $groups = $removeEmptyGroups ? array_filter($this->groups) : $this->groups;
-        $this->groups = null;
-
-        return $groups;
+        return $removeEmptyGroups ? array_filter($groups) : $groups;
     }
 
-    private function updateGroupsForItem(mixed $item): self
+    private function updateGroupsForItem(mixed $item, array $groups): array
     {
         $this->each(
-            fn(CollectionFilter $filter) => match (self::filterIsSatisfiedByItem($filter, $item)) {
-                false => null,
-                true  => $this->groups[$filter->key()][$item->groupByKey($filter->customGroupByData())] = $item,
+            static function(CollectionFilter $filter) use (&$groups, $item): void {
+                if (self::filterIsSatisfiedByItem($filter, $item)) {
+                    $groups[$filter->key()][$item->groupByKey($filter->customGroupByData())] = $item;
+                }
             }
         );
 
-        return $this;
+        return $groups;
     }
 }

--- a/src/FilterableCollectionTrait.php
+++ b/src/FilterableCollectionTrait.php
@@ -3,10 +3,12 @@ declare(strict_types=1);
 
 namespace Kununu\Collection;
 
+use ArrayIterator;
 use Kununu\Collection\Filter\CollectionFilter;
 use Kununu\Collection\Filter\CollectionFilters;
 use Kununu\Collection\Filter\FilterItemTrait;
 
+/** @phpstan-require-extends ArrayIterator */
 trait FilterableCollectionTrait
 {
     use CollectionTrait;

--- a/src/KeyValue.php
+++ b/src/KeyValue.php
@@ -3,64 +3,23 @@ declare(strict_types=1);
 
 namespace Kununu\Collection;
 
-use ArrayAccess;
-use ArrayIterator;
-use Countable;
-use IteratorAggregate;
-use Kununu\Collection\Convertible\FromArray;
-use Kununu\Collection\Convertible\FromIterable;
-use Kununu\Collection\Convertible\ToArray;
-
-final class KeyValue implements ArrayAccess, Countable, IteratorAggregate, FromArray, FromIterable, ToArray
+final class KeyValue implements KeyValueInterface
 {
-    private array $values;
-
-    public function __construct()
-    {
-        $this->values = [];
-    }
-
-    public static function fromArray(array $data): self
-    {
-        return self::fromIterable($data);
-    }
-
-    public static function fromIterable(iterable $data): self
-    {
-        $instance = new self();
-
-        foreach ($data as $key => $value) {
-            $instance->set($key, $value);
-        }
-
-        return $instance;
-    }
-
-    public function values(): array
-    {
-        return array_values($this->values);
-    }
-
-    public function keys(): array
-    {
-        return array_keys($this->values);
-    }
+    use KeyValueTrait;
 
     public function get(int|string $key, mixed $default = null): mixed
     {
         return $this->has($key) ? $this->values[$key] : $default;
     }
 
-    public function set(int|string $key, mixed $value): self
-    {
-        $this->values[$key] = $value;
-
-        return $this;
-    }
-
     public function has(int|string $key): bool
     {
         return array_key_exists($key, $this->values);
+    }
+
+    public function keys(): array
+    {
+        return array_keys($this->values);
     }
 
     public function remove(int|string $key): self
@@ -70,39 +29,10 @@ final class KeyValue implements ArrayAccess, Countable, IteratorAggregate, FromA
         return $this;
     }
 
-    public function toArray(): array
+    public function set(int|string $key, mixed $value): self
     {
-        return $this->values;
-    }
+        $this->values[$key] = $value;
 
-    public function count(): int
-    {
-        return count($this->values);
-    }
-
-    /** @return ArrayIterator<int|string, mixed> */
-    public function getIterator(): ArrayIterator
-    {
-        return new ArrayIterator($this->values);
-    }
-
-    public function offsetExists(mixed $offset): bool
-    {
-        return $this->has($offset);
-    }
-
-    public function offsetGet(mixed $offset): mixed
-    {
-        return $this->get($offset);
-    }
-
-    public function offsetSet(mixed $offset, mixed $value): void
-    {
-        $this->set($offset, $value);
-    }
-
-    public function offsetUnset(mixed $offset): void
-    {
-        $this->remove($offset);
+        return $this;
     }
 }

--- a/src/KeyValueInterface.php
+++ b/src/KeyValueInterface.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Collection;
+
+use ArrayAccess;
+use Countable;
+use IteratorAggregate;
+use Kununu\Collection\Convertible\FromArray;
+use Kununu\Collection\Convertible\FromIterable;
+use Kununu\Collection\Convertible\ToArray;
+
+interface KeyValueInterface extends ArrayAccess, Countable, IteratorAggregate, FromArray, FromIterable, ToArray
+{
+}

--- a/src/KeyValueTrait.php
+++ b/src/KeyValueTrait.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\Collection;
+
+use ArrayIterator;
+
+trait KeyValueTrait
+{
+    private array $values = [];
+
+    /** @param array<string, mixed> $data */
+    public static function fromArray(array $data): self|static
+    {
+        return self::fromIterable($data);
+    }
+
+    /** @param iterable<string, mixed> $data */
+    public static function fromIterable(iterable $data): self|static
+    {
+        // @phpstan-ignore new.static
+        $instance = new static();
+
+        foreach ($data as $key => $value) {
+            $instance->set($key, $value);
+        }
+
+        return $instance;
+    }
+
+    public function count(): int
+    {
+        return count($this->values);
+    }
+
+    /** @return ArrayIterator<int|string, mixed> */
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->values);
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return $this->has($offset);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->get($offset);
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->set($offset, $value);
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        $this->remove($offset);
+    }
+
+    public function toArray(): array
+    {
+        return $this->values;
+    }
+
+    public function values(): array
+    {
+        return array_values($this->values);
+    }
+}

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -6,8 +6,8 @@ namespace Kununu\Collection\Tests;
 use ArrayIterator;
 use Exception;
 use Generator;
-use InvalidArgumentException;
 use Kununu\Collection\Collection;
+use Kununu\Collection\Exception\NotSameCollectionTypeException;
 use Kununu\Collection\Tests\Stub\AbstractItemStub;
 use Kununu\Collection\Tests\Stub\AutoSortedCollectionStub;
 use Kununu\Collection\Tests\Stub\CollectionStub;
@@ -253,6 +253,17 @@ final class CollectionTest extends TestCase
 
         self::assertFalse($collection->empty());
         self::assertTrue($collection->hasMultipleItems());
+    }
+
+    public function testCollectionOrNull(): void
+    {
+        $collection = new CollectionStub();
+
+        self::assertNull($collection->collectionOrNull());
+
+        $collection->add(1);
+
+        self::assertSame($collection, $collection->collectionOrNull());
     }
 
     public function testUnique(): void
@@ -576,10 +587,66 @@ final class CollectionTest extends TestCase
         self::assertEquals([4, 5], $collection1->diff($collection2)->toArray());
         self::assertEquals([6, 7], $collection2->diff($collection1)->toArray());
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(NotSameCollectionTypeException::class);
         $this->expectExceptionMessage('Other collection must be of the same type');
 
         $collection1->diff(new FilterableCollectionStub());
+    }
+
+    public function testIntersect(): void
+    {
+        $collection1 = CollectionStub::fromIterable([1, 2, 3, 4, 5]);
+        $collection2 = CollectionStub::fromIterable([1, 2, 3, 6, 7]);
+
+        self::assertEquals([1, 2, 3], $collection1->intersect($collection2)->toArray());
+        self::assertEquals([1, 2, 3], $collection2->intersect($collection1)->toArray());
+
+        $this->expectException(NotSameCollectionTypeException::class);
+        $this->expectExceptionMessage('Other collection must be of the same type');
+
+        $collection1->intersect(new FilterableCollectionStub());
+    }
+
+    public function testMerge(): void
+    {
+        $collection1 = CollectionStub::fromIterable([1, 2, 3]);
+        $collection2 = CollectionStub::fromIterable([4, 5]);
+        $collection3 = CollectionStub::fromIterable([6]);
+
+        $merged = $collection1->merge($collection2, $collection3);
+
+        self::assertEquals([1, 2, 3, 4, 5, 6], $merged->toArray());
+        // Source collections are left untouched
+        self::assertEquals([1, 2, 3], $collection1->toArray());
+        self::assertEquals([4, 5], $collection2->toArray());
+
+        // Calling merge with no arguments produces a copy of the collection
+        self::assertEquals([1, 2, 3], $collection1->merge()->toArray());
+    }
+
+    public function testMergeUsesAppendOfResultingCollection(): void
+    {
+        $collection1 = new DTOCollectionStub(new DTOStub('a', 1), new DTOStub('b', 2));
+        $collection2 = new DTOCollectionStub(new DTOStub('b', 3), new DTOStub('c', 4));
+
+        // DTOCollectionStub::append keys items by their field, so merging via append
+        // overwrites the duplicated "b" entry with the value coming from $collection2
+        self::assertEquals(
+            [
+                'a' => ['field' => 'a', 'value' => 1],
+                'b' => ['field' => 'b', 'value' => 3],
+                'c' => ['field' => 'c', 'value' => 4],
+            ],
+            $collection1->merge($collection2)->toArray()
+        );
+    }
+
+    public function testMergeThrowsWhenCollectionsAreNotTheSameType(): void
+    {
+        $this->expectException(NotSameCollectionTypeException::class);
+        $this->expectExceptionMessage('Other collection must be of the same type');
+
+        CollectionStub::fromIterable([1, 2, 3])->merge(new FilterableCollectionStub());
     }
 
     #[DataProvider('eachDataProvider')]

--- a/tests/EnumKeyValue/AbstractEnumKeyValueTest.php
+++ b/tests/EnumKeyValue/AbstractEnumKeyValueTest.php
@@ -91,6 +91,27 @@ final class AbstractEnumKeyValueTest extends TestCase
         $this->keyValueNoRequired->get(EnumStub::Key1);
     }
 
+    public function testOffsetGetWithValidKeys(): void
+    {
+        self::assertEquals(self::KEY_1_VALUE, $this->keyValue->offsetGet(EnumStub::Key1));
+        self::assertEquals(self::KEY_1_VALUE, $this->keyValue->offsetGet(self::KEY_1));
+        self::assertEquals(self::KEY_1_VALUE, $this->keyValue[self::KEY_1]);
+
+        self::assertEquals(self::KEY_2_VALUE, $this->keyValue->offsetGet(EnumStub::Key2));
+        self::assertEquals(self::KEY_2_VALUE, $this->keyValue->offsetGet(self::KEY_2));
+        self::assertEquals(self::KEY_2_VALUE, $this->keyValue[self::KEY_2]);
+
+        self::assertNull($this->keyValue->offsetGet(EnumStub::Key3));
+    }
+
+    public function testOffsetGetWithInvalidKey(): void
+    {
+        $this->expectException(ValueError::class);
+        $this->expectExceptionMessage($this->invalidCaseMessage);
+
+        $this->keyValue->offsetGet(self::KEY_INVALID);
+    }
+
     public function testGetIterator(): void
     {
         $result = [];
@@ -132,6 +153,26 @@ final class AbstractEnumKeyValueTest extends TestCase
         $this->keyValue->has(self::KEY_INVALID);
     }
 
+    public function testOffsetExistsWithValidKeys(): void
+    {
+        self::assertTrue($this->keyValue->offsetExists(EnumStub::Key1));
+        self::assertTrue($this->keyValue->offsetExists(self::KEY_1));
+
+        self::assertTrue($this->keyValue->offsetExists(EnumStub::Key2));
+        self::assertTrue($this->keyValue->offsetExists(self::KEY_2));
+
+        self::assertFalse($this->keyValue->offsetExists(EnumStub::Key3));
+        self::assertFalse($this->keyValue->offsetExists(self::KEY_3));
+    }
+
+    public function testOffsetExistsWithInvalidKey(): void
+    {
+        $this->expectException(ValueError::class);
+        $this->expectExceptionMessage($this->invalidCaseMessage);
+
+        $this->keyValue->offsetExists(self::KEY_INVALID);
+    }
+
     public function testKeys(): void
     {
         self::assertEquals([EnumStub::Key1, EnumStub::Key2], $this->keyValue->keys(false));
@@ -163,6 +204,34 @@ final class AbstractEnumKeyValueTest extends TestCase
         $this->keyValue->remove(self::KEY_INVALID);
     }
 
+    public function testOffsetUnsetWithValidKeys(): void
+    {
+        $kv = new EnumKeyValueStub()->setKey2('hello')->setKey3(5.0);
+
+        self::assertTrue($kv->hasKey2());
+        self::assertTrue($kv->hasKey3());
+
+        unset($kv[self::KEY_2]);
+        $kv->offsetUnset(EnumStub::Key3);
+
+        self::assertFalse($kv->hasKey2());
+        self::assertFalse($kv->hasKey3());
+
+        $kv = new EnumKeyValueStub()->setKey2('hello')->setKey3(5.0);
+
+        $kv->offsetUnset(self::KEY_3);
+
+        self::assertFalse($kv->hasKey3());
+    }
+
+    public function testOffsetUnsetWithInvalidValidKey(): void
+    {
+        $this->expectException(ValueError::class);
+        $this->expectExceptionMessage($this->invalidCaseMessage);
+
+        $this->keyValue->offsetUnset(self::KEY_INVALID);
+    }
+
     public function testSetWithValidKeys(): void
     {
         $kv = new EnumKeyValueStub();
@@ -182,6 +251,23 @@ final class AbstractEnumKeyValueTest extends TestCase
         $this->expectExceptionMessage($this->invalidCaseMessage);
 
         $this->keyValue->set(self::KEY_INVALID, self::KEY_1_VALUE);
+    }
+
+    public function testOffsetSetWithValidKeys(): void
+    {
+        $kv = new EnumKeyValueStub();
+
+        self::assertFalse($kv->hasKey1());
+        self::assertFalse($kv->hasKey2());
+        self::assertFalse($kv->hasKey3());
+
+        $kv->offsetSet(self::KEY_1, self::KEY_1_VALUE);
+        $kv[self::KEY_2] = self::KEY_2_VALUE;
+        $kv->offsetSet(self::KEY_3, self::KEY_3_VALUE);
+
+        self::assertEquals(self::KEY_1_VALUE, $kv->getKey1());
+        self::assertEquals(self::KEY_2_VALUE, $kv->getKey2());
+        self::assertEquals(self::KEY_3_VALUE, $kv->getKey3());
     }
 
     public function testToArray(): void

--- a/tests/Stub/AutoSortedCollectionStub.php
+++ b/tests/Stub/AutoSortedCollectionStub.php
@@ -8,15 +8,18 @@ use Kununu\Collection\AutoSortableOffsetSetTrait;
 use Kununu\Collection\Collection;
 
 /**
- * @method static self fromIterable(iterable $data)
- * @method        self add(mixed $value)
- * @method        self clear()
- * @method        int  count()
- * @method        self diff(Collection $other)
- * @method        self duplicates(bool $strict = true, bool $uniques = false)
- * @method        self each(callable $function, bool $rewind = true)
- * @method        self reverse()
- * @method        self unique()
+ * @method static self      fromIterable(iterable $data)
+ * @method        self      add(mixed $value)
+ * @method        self      clear()
+ * @method        self|null collectionOrNull()
+ * @method        int       count()
+ * @method        self      diff(Collection $other)
+ * @method        self      duplicates(bool $strict = true, bool $uniques = false)
+ * @method        self      each(callable $function, bool $rewind = true)
+ * @method        self      intersect(Collection $other)
+ * @method        self      merge(Collection ...$others)
+ * @method        self      reverse()
+ * @method        self      unique()
  */
 final class AutoSortedCollectionStub extends AbstractCollection
 {

--- a/tests/Stub/CollectionStub.php
+++ b/tests/Stub/CollectionStub.php
@@ -7,15 +7,18 @@ use Kununu\Collection\AbstractCollection;
 use Kununu\Collection\Collection;
 
 /**
- * @method static self fromIterable(iterable $data)
- * @method        self add(mixed $value)
- * @method        self clear()
- * @method        int  count()
- * @method        self diff(Collection $other)
- * @method        self duplicates(bool $strict = true, bool $uniques = false)
- * @method        self each(callable $function, bool $rewind = true)
- * @method        self reverse()
- * @method        self unique()
+ * @method static self      fromIterable(iterable $data)
+ * @method        self      add(mixed $value)
+ * @method        self      clear()
+ * @method        self|null collectionOrNull()
+ * @method        int       count()
+ * @method        self      diff(Collection $other)
+ * @method        self      duplicates(bool $strict = true, bool $uniques = false)
+ * @method        self      each(callable $function, bool $rewind = true)
+ * @method        self      intersect(Collection $other)
+ * @method        self      merge(Collection ...$others)
+ * @method        self      reverse()
+ * @method        self      unique()
  */
 final class CollectionStub extends AbstractCollection
 {

--- a/tests/Stub/DTOCollectionStub.php
+++ b/tests/Stub/DTOCollectionStub.php
@@ -8,15 +8,18 @@ use Kununu\Collection\AbstractCollection;
 use Kununu\Collection\Collection;
 
 /**
- * @method static self fromIterable(iterable $data)
- * @method        self add(mixed $value)
- * @method        self clear()
- * @method        int  count()
- * @method        self diff(Collection $other)
- * @method        self duplicates(bool $strict = true, bool $uniques = false)
- * @method        self each(callable $function, bool $rewind = true)
- * @method        self reverse()
- * @method        self unique()
+ * @method static self      fromIterable(iterable $data)
+ * @method        self      add(mixed $value)
+ * @method        self      clear()
+ * @method        self|null collectionOrNull()
+ * @method        int       count()
+ * @method        self      diff(Collection $other)
+ * @method        self      duplicates(bool $strict = true, bool $uniques = false)
+ * @method        self      each(callable $function, bool $rewind = true)
+ * @method        self      intersect(Collection $other)
+ * @method        self      merge(Collection ...$others)
+ * @method        self      reverse()
+ * @method        self      unique()
  */
 final class DTOCollectionStub extends AbstractCollection
 {

--- a/tests/Stub/FilterableCollectionStub.php
+++ b/tests/Stub/FilterableCollectionStub.php
@@ -8,16 +8,20 @@ use Kununu\Collection\Collection;
 use Kununu\Collection\Filter\CollectionFilter;
 
 /**
- * @method static self fromIterable(iterable $data)
- * @method        self add(mixed $value)
- * @method        self clear()
- * @method        int  count()
- * @method        self diff(Collection $other)
- * @method        self duplicates(bool $strict = true, bool $uniques = false)
- * @method        self each(callable $function, bool $rewind = true)
- * @method        self reverse()
- * @method        self unique()
- * @method        self filter(CollectionFilter $filter)
+ * @method static self      fromIterable(iterable $data)
+ * @method        self      add(mixed $value)
+ * @method        self      clear()
+ * @method        self|null collectionOrNull()
+ * @method        int       count()
+ * @method        self      diff(Collection $other)
+ * @method        self      duplicates(bool $strict = true, bool $uniques = false)
+ * @method        self      each(callable $function, bool $rewind = true)
+ * @method        self      filter(CollectionFilter $filter)
+ * @method        self      filterWith(callable $function, bool $rewind = true)
+ * @method        self      intersect(Collection $other)
+ * @method        self      merge(Collection ...$others)
+ * @method        self      reverse()
+ * @method        self      unique()
  */
 final class FilterableCollectionStub extends AbstractFilterableCollection
 {

--- a/tests/Stub/ScalarCollectionStub.php
+++ b/tests/Stub/ScalarCollectionStub.php
@@ -10,15 +10,18 @@ use Kununu\Collection\Collection;
 use Kununu\Collection\Convertible\ToInt;
 
 /**
- * @method static self fromIterable(iterable $data)
- * @method        self add(mixed $value)
- * @method        self clear()
- * @method        int  count()
- * @method        self diff(Collection $other)
- * @method        self duplicates(bool $strict = true, bool $uniques = false)
- * @method        self each(callable $function, bool $rewind = true)
- * @method        self reverse()
- * @method        self unique()
+ * @method static self      fromIterable(iterable $data)
+ * @method        self      add(mixed $value)
+ * @method        self      clear()
+ * @method        self|null collectionOrNull()
+ * @method        int       count()
+ * @method        self      diff(Collection $other)
+ * @method        self      duplicates(bool $strict = true, bool $uniques = false)
+ * @method        self      each(callable $function, bool $rewind = true)
+ * @method        self      intersect(Collection $other)
+ * @method        self      merge(Collection ...$others)
+ * @method        self      reverse()
+ * @method        self      unique()
  */
 final class ScalarCollectionStub extends AbstractCollection
 {


### PR DESCRIPTION
# Description

The objective of this PR is to update the code base  so that the library is more stable and structured, and also to add some new functionality.

## Details

### Added

- `Collection::intersect(self $other): self|static`
  - Returns a new collection with the intersection between two collections of the same type (throws `NotSameCollectionTypeException` if the other collection is not the same type).
- `Collection::merge(self ...$others): self|static`
  - Returns a new collection with the items of this collection followed by the items of the given ones.
  - Items are added through the collection's own `append`, so any overridden append logic (validation, transformation, keying) is honored.
  - Same-type guard as `diff`/`intersect`.
- `Collection::collectionOrNull(): self|static|null`
  - Returns `null` when the collection is empty, otherwise the collection itself.
- `Exception\NotSameCollectionTypeException`
  - Thrown by `diff`, `intersect`, and `merge` when the other collection is not the same type
  - Extends `InvalidArgumentException`, so existing `catch (InvalidArgumentException)` handlers keep working.
- `AbstractBasicItem::getAllProperties` is now cached per class, instead of being recomputed on each `new` call.
- `KeyValueInterface` - a shared interface for key-value containers, implemented by both `KeyValue` and `EnumKeyValue\AbstractEnumKeyValue`.
- `KeyValueTrait` - extracts the shared storage, iteration, and `ArrayAccess` behavior of the key-value containers so it can be reused by custom implementations.
- `EnumKeyValue\AbstractEnumKeyValue` now supports `ArrayAccess` (e.g. `$item['key']`), inherited from the shared `KeyValueTrait`.

### Changed

- `@phpstan-require-extends ArrayIterator` was added to `CollectionTrait` and `FilterableCollectionTrait` to document (and let static analysis surface) the existing requirement that these traits can only be used by classes extending `ArrayIterator`.
- `KeyValue` and `EnumKeyValue\AbstractEnumKeyValue` now implement the new `KeyValueInterface` (previously each declared the underlying `ArrayAccess`/`Countable`/`IteratorAggregate`/`FromArray`/`FromIterable`/`ToArray` interfaces individually). All existing `instanceof` checks against those interfaces continue to hold.
- Documentation updated for the new methods.

### Backwards compatibility

- **Extending `AbstractCollection`/`AbstractFilterableCollection`** the upgrade is drop-in
  - The new methods (`intersect`, `merge`, `collectionOrNull`) are inherited automatically
  - No action needed unless your subclass already declares a method with one of those names
    - **Incompatible signature** ⇒ fatal `Declaration ... must be compatible with ...` error at class load.
      - Rename your method or align its signature with the interface.
    - **Compatible signature** ⇒ no error, but your implementation silently overrides the library's. - Verify that is intended (and that nothing relied on the new built-in behavior).
- **Direct implementers of `Collection`** (not extending the abstract classes/not using `CollectionTrait`) must add the three new methods to satisfy the interface.
- **Exception type:**
  - `diff`, `intersect`, and `merge` now throw `Exception\NotSameCollectionTypeException` instead of a plain `InvalidArgumentException` when the other collection is not the same type
  - It extends `InvalidArgumentException`, so `catch (InvalidArgumentException)` keeps working
    - Update any assertions or checks that compare the exact exception class.
- **`AbstractEnumKeyValue` now also implements `ArrayAccess`.** This is additive — no action needed. (Only relevant if a subclass already declared its own `offset*` methods, which would now override the inherited ones.)

### Other

- Introduce `CHANGELOG.md`
- Update CI components and dev dependencies
- Added a `suggest` entry for `phpunit/phpunit` (only needed by consumers extending `AbstractCollectionTestCase`).
- `composer test`/`composer test-coverage` now run with `zend.assertions=1`, matching CI.
